### PR TITLE
Update packaging bits to build scst-dbg package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -415,10 +415,16 @@ dpkg: ../scst_$(VERSION).orig.tar.gz
 	echo "KVER=$(KVER)" &&						\
 	sed 's/%{scst_version}/$(VERSION)/'				\
 	  <debian/scst.dkms.in >debian/scst.dkms &&			\
-	sed 's/%{KVER}/$(KVER)/'					\
-	  <debian/scst.preinst.in >debian/scst.preinst &&		\
-	sed 's/%{KVER}/$(KVER)/'					\
-	  <debian/scst.postinst.in >debian/scst.postinst &&		\
+	if echo "$(KVER)" | grep -q "debug+truenas"; then			\
+		mv debian/scst.install debian/scst-dbg.install &&		\
+		sed 's/%{KVER}/$(KVER)/'					\
+		  <debian/scst.postinst.in >debian/scst-dbg.postinst;		\
+	else									\
+		sed 's/%{KVER}/$(KVER)/'					\
+		  <debian/scst.preinst.in >debian/scst.preinst &&		\
+		sed 's/%{KVER}/$(KVER)/'					\
+		  <debian/scst.postinst.in >debian/scst.postinst;		\
+	fi &&								\
 	output_files=(							\
 		../*_$(VERSION)-$(DEBIAN_REVISION)_*.deb		\
 		../*_$(VERSION)-$(DEBIAN_REVISION)_*.ddeb		\

--- a/debian/control.dbgmodules
+++ b/debian/control.dbgmodules
@@ -1,0 +1,18 @@
+Source: scst
+Section: net
+Priority: optional
+Maintainer: Vladislav Bolkhovitin <vst@vlnb.net>
+Build-Depends: debhelper (>= 9),
+ quilt,
+ dpkg-dev (>= 1.13.19)
+Standards-Version: 4.1.1
+Homepage: http://scst.sourceforge.net
+
+Package: scst-dbg
+Architecture: any
+Depends: ${misc:Depends}
+Conflicts: scst-dkms
+Description: Generic SCSI target framework
+ SCST is a SCSI target framework that allows local block device data to be
+ accessed over a storage network via the iSCSI, FC, SRP or FCoE protocol.
+ This package contains the SCST kernel modules.

--- a/debian/rules
+++ b/debian/rules
@@ -32,8 +32,13 @@ VERSION:=$(shell head -n1 debian/changelog | sed 's/.*(\([0-9.]*\).*).*/\1/')
 clean:
 	dh_testdir &&							\
 	dh_prep -Xqla_isp/TAGS -Xdebian/changelog &&			\
-	scripts/clean-source-tree -x debian/changelog -x debian/compat -x debian/scst.preinst \
-	    -x debian/scst.postinst
+	if echo "$(KVER)" | grep -q "debug+truenas"; then			\
+		scripts/clean-source-tree -x debian/changelog -x debian/compat -x debian/scst-dbg.install	\
+		    -x debian/scst-dbg.postinst ;	\
+	else				\
+		scripts/clean-source-tree -x debian/changelog -x debian/compat -x debian/scst.preinst \
+		    -x debian/scst.postinst ;		\
+	fi
 
 build:
 	[ -n "$(QLA_INI_DIR)" ] &&					\


### PR DESCRIPTION
This commits updates the Debian packaging bits to build scst-dbg package for kernel modules linked with debug kernel.

SCST kernel modules linked with debug kernel need to packaged differently so that they can co-exist with SCST package for modules built for production kernel.

The updates in packaging bits are minimal would only apply if KVERS environment variable is configured for debug kernel for TrueNAS SCALE.