### PR TITLE
NAS-126694 / 23.10.2 / scst.h, scst, device handlers: Fix scst_replace_port_info

### DIFF
--- a/scst/include/scst.h
+++ b/scst/include/scst.h
@@ -2315,6 +2315,8 @@ struct scst_cmd {
 
 	uint32_t tgt_sn; /* SN set by target driver (for TM purposes) */
 
+	uint16_t tg_id; /* Only used during TYPE_DISK INQUIRY EVPD=0x83 */
+
 	uint8_t *cdb; /* Pointer on CDB. Points on cdb_buf for small CDBs. */
 	unsigned short cdb_len;
 	uint8_t cdb_buf[SCST_MAX_CDB_SIZE];
@@ -4518,6 +4520,13 @@ static inline bool scst_cmd_aborted_on_xmit(struct scst_cmd *cmd)
 static inline bool scst_get_cmd_dev_d_sense(struct scst_cmd *cmd)
 {
 	return (cmd->dev != NULL) ? cmd->dev->d_sense : 0;
+}
+
+/* Returns if command is INQUIRY EVPD=0x83 (device identification) */
+static inline bool scst_cmd_inquired_dev_ident(struct scst_cmd *cmd)
+{
+	return (cmd->cdb[0] == INQUIRY) && ((cmd->cdb[1] & 0x01/*EVPD*/) == 0x01) &&
+		(cmd->cdb[2] == 0x83/*device identification*/);
 }
 
 /*

--- a/scst/src/dev_handlers/scst_disk.c
+++ b/scst/src/dev_handlers/scst_disk.c
@@ -375,6 +375,15 @@ static enum scst_exec_res disk_exec(struct scst_cmd *cmd)
 	}
 
 	/*
+	 * If we are passing thru a INQUIRY VPD=0x83 (device identification) then
+	 * we will call scst_replace_port_info on success in scst_pass_through_cmd_done.
+	 * This will run in interrupt context, so we should not perform operations that
+	 * involve mutexes.  Call scst_lookup_tg_id here intead and save the output.
+	 */
+	if (unlikely(scst_cmd_inquired_dev_ident(cmd)))
+		cmd->tg_id = scst_lookup_tg_id(dev, tgt);
+
+	/*
 	 * For PC requests we are going to submit max_hw_sectors used instead
 	 * of max_sectors.
 	 */


### PR DESCRIPTION
`scst_pass_through_cmd_done` can run in interrupt context, and call `scst_replace_port_info`, which in turn was calling `scst_lookup_tg_id`. Since `scst_lookup_tg_id` does a `mutex_lock`, we should not call it from interrupt context.

Add `scst_cmd_inquired_dev_ident` and use in various locations.

----
This is a backport of a commit (https://github.com/truenas/scst/commit/df039cb3e9f549fde3079849f19e5b34186de701) which has been accepted upstream, and is currently part of `truenas-3.8.x` branch.

Also performed some unit testing of 23.10 with this change:

```
[2024-01-22 13:08:53] api2/test_001_iscsi.py::test_06_test_ssh PASSED
[2024-01-22 13:08:56] api2/test_261_iscsi_cmd.py::test_00_setup PASSED
[2024-01-22 13:09:05] api2/test_261_iscsi_cmd.py::test_01_inquiry PASSED
[2024-01-22 13:09:26] api2/test_261_iscsi_cmd.py::test_02_read_capacity16 PASSED
[2024-01-22 13:10:12] api2/test_261_iscsi_cmd.py::test_03_readwrite16_file_extent PASSED
[2024-01-22 13:10:40] api2/test_261_iscsi_cmd.py::test_04_readwrite16_zvol_extent PASSED
[2024-01-22 13:11:08] api2/test_261_iscsi_cmd.py::test_05_chap PASSED
[2024-01-22 13:11:31] api2/test_261_iscsi_cmd.py::test_06_mutual_chap PASSED
[2024-01-22 13:11:55] api2/test_261_iscsi_cmd.py::test_07_report_luns PASSED
[2024-01-22 13:12:27] api2/test_261_iscsi_cmd.py::test_08_snapshot_zvol_extent PASSED
[2024-01-22 13:13:29] api2/test_261_iscsi_cmd.py::test_09_snapshot_file_extent PASSED
[2024-01-22 13:14:28] api2/test_261_iscsi_cmd.py::test_10_target_alias PASSED
[2024-01-22 13:15:00] api2/test_261_iscsi_cmd.py::test_11_modify_portal PASSED
[2024-01-22 13:15:09] api2/test_261_iscsi_cmd.py::test_12_pblocksize_setting PASSED
[2024-01-22 13:15:50] api2/test_261_iscsi_cmd.py::test_13_test_target_name[FILE] PASSED
[2024-01-22 13:16:25] api2/test_261_iscsi_cmd.py::test_13_test_target_name[VOLUME] PASSED
[2024-01-22 13:17:03] api2/test_261_iscsi_cmd.py::test_14_target_lun_extent_modify[FILE] PASSED
[2024-01-22 13:18:07] api2/test_261_iscsi_cmd.py::test_14_target_lun_extent_modify[VOLUME] PASSED
[2024-01-22 13:19:17] api2/test_261_iscsi_cmd.py::test_15_test_isns PASSED
[2024-01-22 13:19:59] api2/test_261_iscsi_cmd.py::TestFixtureInitiatorName::test_16_invalid_initiator_name[None-True] PASSED
[2024-01-22 13:20:12] api2/test_261_iscsi_cmd.py::TestFixtureInitiatorName::test_16_invalid_initiator_name[iqn.1991-05.com.microsoft:fake-host-True] PASSED
[2024-01-22 13:20:16] api2/test_261_iscsi_cmd.py::TestFixtureInitiatorName::test_16_invalid_initiator_name[iqn.1991-05.com.microsoft:fake-/-host-False] PASSED
[2024-01-22 13:20:20] api2/test_261_iscsi_cmd.py::TestFixtureInitiatorName::test_16_invalid_initiator_name[iqn.1991-05.com.microsoft:fake-#-host-False] PASSED
[2024-01-22 13:20:23] api2/test_261_iscsi_cmd.py::TestFixtureInitiatorName::test_16_invalid_initiator_name[iqn.1991-05.com.microsoft:fake-%s-host-False] PASSED
[2024-01-22 13:20:27] api2/test_261_iscsi_cmd.py::TestFixtureInitiatorName::test_16_invalid_initiator_name[iqn.1991-05.com.microsoft:unicode-\u6d4b\u8bd5-ok-True] PASSED
[2024-01-22 13:20:31] api2/test_261_iscsi_cmd.py::TestFixtureInitiatorName::test_16_invalid_initiator_name[iqn.1991-05.com.microsoft:unicode-\u30c6\u30b9\u30c8-ok-True] PASSED
[2024-01-22 13:20:35] api2/test_261_iscsi_cmd.py::TestFixtureInitiatorName::test_16_invalid_initiator_name[iqn.1991-05.com.microsoft:unicode-\u180e-bad-False] PASSED
[2024-01-22 13:20:39] api2/test_261_iscsi_cmd.py::TestFixtureInitiatorName::test_16_invalid_initiator_name[iqn.1991-05.com.microsoft:unicode-\u2009-bad-False] PASSED
[2024-01-22 13:20:42] api2/test_261_iscsi_cmd.py::TestFixtureInitiatorName::test_16_invalid_initiator_name[iqn.1991-05.com.microsoft:unicode-\ufeff-bad-False] PASSED
[2024-01-22 13:20:54] api2/test_261_iscsi_cmd.py::test_17_basic_persistent_reservation PASSED
[2024-01-22 13:21:18] api2/test_261_iscsi_cmd.py::test_18_persistent_reservation_two_initiators PASSED
[2024-01-22 13:22:10] api2/test_261_iscsi_cmd.py::test_19_alua_config PASSED
[2024-01-22 13:26:06] api2/test_261_iscsi_cmd.py::test_20_alua_basic_persistent_reservation PASSED
[2024-01-22 13:26:50] api2/test_261_iscsi_cmd.py::test_21_alua_persistent_reservation_two_initiators PASSED
[2024-01-22 13:28:33] api2/test_261_iscsi_cmd.py::test_22_extended_copy[FILE-FILE] PASSED
[2024-01-22 13:29:14] api2/test_261_iscsi_cmd.py::test_22_extended_copy[FILE-VOLUME] PASSED
[2024-01-22 13:29:59] api2/test_261_iscsi_cmd.py::test_22_extended_copy[VOLUME-FILE] PASSED
[2024-01-22 13:30:44] api2/test_261_iscsi_cmd.py::test_22_extended_copy[VOLUME-VOLUME] PASSED
[2024-01-22 13:31:30] api2/test_261_iscsi_cmd.py::test_23_ha_extended_copy[FILE-FILE] PASSED
[2024-01-22 13:33:07] api2/test_261_iscsi_cmd.py::test_23_ha_extended_copy[FILE-VOLUME] PASSED
[2024-01-22 13:34:46] api2/test_261_iscsi_cmd.py::test_23_ha_extended_copy[VOLUME-FILE] PASSED
[2024-01-22 13:36:25] api2/test_261_iscsi_cmd.py::test_23_ha_extended_copy[VOLUME-VOLUME] PASSED
[2024-01-22 13:38:03] api2/test_261_iscsi_cmd.py::test_24_iscsi_target_disk_login PASSED
[2024-01-22 13:38:57] api2/test_261_iscsi_cmd.py::test_25_resize_target_zvol PASSED
[2024-01-22 13:39:25] api2/test_261_iscsi_cmd.py::test_26_resize_target_file PASSED
[2024-01-22 13:39:50] api2/test_261_iscsi_cmd.py::test_27_initiator_group PASSED
[2024-01-22 13:40:31] api2/test_261_iscsi_cmd.py::test_28_portal_access PASSED
[2024-01-22 13:41:14] api2/test_261_iscsi_cmd.py::test_29_multiple_extents PASSED
[2024-01-22 13:41:41] api2/test_261_iscsi_cmd.py::test_30_target_without_active_extent PASSED
[2024-01-22 13:42:36] api2/test_261_iscsi_cmd.py::test_32_multi_lun_targets PASSED
[2024-01-22 13:43:53] api2/test_261_iscsi_cmd.py::test_99_teardown PASSED

=============================================================================== 51 passed in 2112.85s (0:35:12) ===============================================================================
```