### PR TITLE
NAS-126731 / 24.10/ Disable unused expensive code in addVirtualTarget

### DIFF
--- a/scstadmin/scstadmin.sysfs/scstadmin
+++ b/scstadmin/scstadmin.sysfs/scstadmin
@@ -3024,6 +3024,9 @@ sub addVirtualTarget {
 	my $errorString;
 	my $targets;
 
+	# Disable this code.  Never used but gets expensive as the
+	# target count climbs.
+	if (0) {
 	# Enable all hardware targets before creating virtual ones
 	($targets, $errorString) = $SCST->targets($driver);
 	foreach my $_target (@{$targets}) {
@@ -3034,6 +3037,7 @@ sub addVirtualTarget {
 		    !$$attributes{'enabled'}->{'value'}) {
 			enableTarget($driver, $_target);
 		}
+	}
 	}
 
 	print "\t-> Creating target '$target' for driver '$driver': ";


### PR DESCRIPTION
The code to enable all hardware targets before creating virtual ones becomes more expensive as the target count climbs.

This change reduces the start time of 100 targets from ~30 seconds to around ~13.  [Varies depending on platform, but approx 50% reduction seen everwhere.]