### PR TITLE
NAS-126731 / 23.10.2 / When stopping scst turn off cluster_mode in parallel (by bmeagherix)

### DIFF
--- a/scstadmin/init.d/scst
+++ b/scstadmin/init.d/scst
@@ -269,6 +269,17 @@ stop_scst() {
             return 1
         fi
 
+        # Disable iSCSI
+        if [ -f /sys/kernel/scst_tgt/targets/iscsi/enabled ]; then
+            echo 0 > /sys/kernel/scst_tgt/targets/iscsi/enabled
+        fi
+
+        # Turn off any cluster_mode in parallel
+        for cm in /sys/kernel/scst_tgt/devices/*/cluster_mode ; do
+            echo 0 > "$cm" &
+        done
+        wait
+
         unload_scst
 }
 


### PR DESCRIPTION
Clearing `cluster_mode` in parallel leads to a faster (and cleaner) `dlm` cleanup than just stopping `scst`.  (Approx 1 sec for 100 clustered extents.)

Original PR: https://github.com/truenas/scst/pull/23
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126731