### PR TITLE
NAS-132244 / 25.04 / Reenable some initialization code for Fibre Channel

### DIFF
--- a/scstadmin/scstadmin.sysfs/scstadmin
+++ b/scstadmin/scstadmin.sysfs/scstadmin
@@ -3033,7 +3033,7 @@ sub addVirtualTarget {
 
 	# Disable this code.  Never used but gets expensive as the
 	# target count climbs.
-	if (0) {
+	if ($driver ne "iscsi") {
 	# Enable all hardware targets before creating virtual ones
 	($targets, $errorString) = $SCST->targets($driver);
 	foreach my $_target (@{$targets}) {


### PR DESCRIPTION
Previously had disabled some code for performance reasons because it was unnecessary for our iSCSI targets.

Turns out that we **do** need it for Fibre Channel targets, so reenable for non-iscsi.