### PR TITLE
Rebase truenas-3.9.0-pre on master

### DIFF
--- a/.github/workflows/checkpatch_pull.yml
+++ b/.github/workflows/checkpatch_pull.yml
@@ -24,31 +24,4 @@ jobs:
 
       - name: Run checkpatch.pl
         run: |
-          ignore=(
-            MISSING_SIGN_OFF
-            EMAIL_SUBJECT
-            UNKNOWN_COMMIT_ID
-            NO_AUTHOR_SIGN_OFF
-            COMMIT_LOG_USE_LINK
-            BAD_REPORTED_BY_LINK
-            FILE_PATH_CHANGES
-            SPDX_LICENSE_TAG
-            LINUX_VERSION_CODE
-            CONSTANT_COMPARISON
-            NEW_TYPEDEFS
-            SPACING
-          )
-          ignore_str=${ignore[*]}
-
-          base_commit=${{github.event.pull_request.base.sha}}
-          commits=$(git log --pretty=format:"%h" $base_commit..HEAD)
-          err=0
-
-          for commit in $commits; do
-            echo "Running checkpatch.pl for commit $commit"
-            echo "========================================"
-            git format-patch -1 --stdout $commit | ./checkpatch.pl --no-tree --show-types --strict --ignore="${ignore_str// /,}" - || err=1
-            echo
-          done
-
-          exit $err
+          CHECKPATCH_PATH=. ./scripts/checkpatch_commits ${{github.event.pull_request.base.sha}}

--- a/.github/workflows/checkpatch_pull.yml
+++ b/.github/workflows/checkpatch_pull.yml
@@ -1,4 +1,4 @@
-name: Checkpatch upon pull
+name: Checkpatch upon pull request
 
 on:
   pull_request:

--- a/.github/workflows/checkpatch_pull.yml
+++ b/.github/workflows/checkpatch_pull.yml
@@ -47,7 +47,7 @@ jobs:
           for commit in $commits; do
             echo "Running checkpatch.pl for commit $commit"
             echo "========================================"
-            git format-patch -1 --stdout $commit | ./checkpatch.pl --no-tree --show-types --ignore="${ignore_str// /,}" - || err=1
+            git format-patch -1 --stdout $commit | ./checkpatch.pl --no-tree --show-types --strict --ignore="${ignore_str// /,}" - || err=1
             echo
           done
 

--- a/.github/workflows/checkpatch_push.yml
+++ b/.github/workflows/checkpatch_push.yml
@@ -45,4 +45,4 @@ jobs:
           )
           ignore_str=${ignore[*]}
 
-          git format-patch -1 --stdout | ./checkpatch.pl --no-tree --show-types --ignore="${ignore_str// /,}" -
+          git format-patch -1 --stdout | ./checkpatch.pl --no-tree --show-types --strict --ignore="${ignore_str// /,}" -

--- a/.github/workflows/checkpatch_push.yml
+++ b/.github/workflows/checkpatch_push.yml
@@ -29,20 +29,4 @@ jobs:
 
       - name: Run checkpatch.pl
         run: |
-          ignore=(
-            MISSING_SIGN_OFF
-            EMAIL_SUBJECT
-            UNKNOWN_COMMIT_ID
-            NO_AUTHOR_SIGN_OFF
-            COMMIT_LOG_USE_LINK
-            BAD_REPORTED_BY_LINK
-            FILE_PATH_CHANGES
-            SPDX_LICENSE_TAG
-            LINUX_VERSION_CODE
-            CONSTANT_COMPARISON
-            NEW_TYPEDEFS
-            SPACING
-          )
-          ignore_str=${ignore[*]}
-
-          git format-patch -1 --stdout | ./checkpatch.pl --no-tree --show-types --strict --ignore="${ignore_str// /,}" -
+          git format-patch -1 --stdout | CHECKPATCH_PATH=. ./scripts/checkpatch

--- a/.github/workflows/run_regression_tests.yaml
+++ b/.github/workflows/run_regression_tests.yaml
@@ -1,10 +1,13 @@
-name: Regression tests upon push
+name: Run regression tests
 
 on:
   push:
     branches:
       - master
       - nightly/update
+  pull_request:
+    branches:
+      - master
 
 jobs:
   regression_tests:

--- a/fcst/ft_sess.c
+++ b/fcst/ft_sess.c
@@ -19,7 +19,6 @@
 #include <linux/module.h>
 #include <linux/mutex.h>
 #include <linux/hash.h>
-#include <asm/unaligned.h>
 #include <scsi/libfc.h>
 #include <scsi/fc/fc_els.h>
 #include "fcst.h"

--- a/iscsi-scst/include/iscsit_transport.h
+++ b/iscsi-scst/include/iscsit_transport.h
@@ -66,4 +66,3 @@ extern void iscsit_unreg_transport(struct iscsit_transport *t);
 extern struct iscsit_transport *iscsit_get_transport(enum iscsit_transport_type type);
 
 #endif /* __ISCSI_TRANSPORT_H__ */
-

--- a/iscsi-scst/kernel/iscsi.c
+++ b/iscsi-scst/kernel/iscsi.c
@@ -22,7 +22,6 @@
 #include <net/tcp.h>
 #include <scsi/scsi.h>
 #include <asm/byteorder.h>
-#include <asm/unaligned.h>
 #ifdef INSIDE_KERNEL_TREE
 #include <scst/iscsit_transport.h>
 #else

--- a/iscsi-scst/kernel/isert-scst/iser_rdma.c
+++ b/iscsi-scst/kernel/isert-scst/iser_rdma.c
@@ -979,8 +979,7 @@ static struct isert_device *isert_device_create(struct ib_device *ib_dev)
 
 		snprintf(wq_name, sizeof(wq_name), "isert_cq_%p", cq_desc);
 		cq_desc->cq_workqueue = alloc_workqueue(wq_name,
-							WQ_CPU_INTENSIVE|
-							WQ_MEM_RECLAIM, 1);
+							WQ_CPU_INTENSIVE | WQ_MEM_RECLAIM, 1);
 		if (unlikely(!cq_desc->cq_workqueue)) {
 			PRINT_ERROR("Failed to alloc iser cq work queue for dev:%s",
 				    ib_dev->name);

--- a/iscsi-scst/kernel/isert-scst/isert_login.c
+++ b/iscsi-scst/kernel/isert-scst/isert_login.c
@@ -889,7 +889,9 @@ static dev_t devno;
 
 static const struct file_operations listener_fops = {
 	.owner		= THIS_MODULE,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
 	.llseek		= no_llseek,
+#endif
 	.read		= isert_listen_read,
 	.unlocked_ioctl	= isert_listen_ioctl,
 	.compat_ioctl	= isert_listen_ioctl,
@@ -900,7 +902,9 @@ static const struct file_operations listener_fops = {
 
 static const struct file_operations conn_fops = {
 	.owner		= THIS_MODULE,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
 	.llseek		= no_llseek,
+#endif
 	.read		= isert_read,
 	.write		= isert_write,
 	.unlocked_ioctl	= isert_ioctl,

--- a/qla2x00t-32gbit/qla2x00-target/qla_tgt.c
+++ b/qla2x00t-32gbit/qla2x00-target/qla_tgt.c
@@ -37,7 +37,6 @@
 #include <linux/delay.h>
 #include <linux/list.h>
 #include <linux/workqueue.h>
-#include <asm/unaligned.h>
 #include <scsi/scsi.h>
 #include <scsi/scsi_host.h>
 #include <scsi/scsi_tcq.h>

--- a/qla2x00t-32gbit/qla2x00-target/scst_qla2xxx.c
+++ b/qla2x00t-32gbit/qla2x00-target/scst_qla2xxx.c
@@ -43,7 +43,6 @@
 #include <linux/types.h>
 #include <linux/delay.h>
 #include <linux/list.h>
-#include <asm/unaligned.h>
 #include <linux/vmalloc.h>
 #ifdef INSIDE_KERNEL_TREE
 #include <scst/scst.h>

--- a/qla2x00t-32gbit/qla_def.h
+++ b/qla2x00t-32gbit/qla_def.h
@@ -2681,7 +2681,6 @@ typedef struct fc_port {
 	struct kref sess_kref;
 	struct qla_tgt *tgt;
 	unsigned long expires;
-	struct list_head del_list_entry;
 	struct work_struct free_work;
 	struct work_struct reg_work;
 	uint64_t jiffies_at_registration;

--- a/qla2x00t-32gbit/qla_def.h
+++ b/qla2x00t-32gbit/qla_def.h
@@ -28,6 +28,11 @@
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 0, 0)
 #include <linux/aer.h>
 #endif
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+#include <asm/unaligned.h>
+#else
+#include <linux/unaligned.h>
+#endif
 #include <linux/mutex.h>
 #include <linux/btree.h>
 #include <linux/version.h>

--- a/qla2x00t-32gbit/qla_dsd.h
+++ b/qla2x00t-32gbit/qla_dsd.h
@@ -1,7 +1,14 @@
 #ifndef _QLA_DSD_H_
 #define _QLA_DSD_H_
 
+#ifndef INSIDE_KERNEL_TREE
+#include <linux/version.h>
+#endif
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
 #include <asm/unaligned.h>
+#else
+#include <linux/unaligned.h>
+#endif
 
 /* 32-bit data segment descriptor (8 bytes) */
 struct dsd32 {

--- a/qla2x00t-32gbit/qla_os.c
+++ b/qla2x00t-32gbit/qla_os.c
@@ -3568,11 +3568,13 @@ qla2x00_probe_one(struct pci_dev *pdev, const struct pci_device_id *id)
 
 	if (IS_QLA8031(ha) || IS_MCTP_CAPABLE(ha)) {
 		sprintf(wq_name, "qla2xxx_%lu_dpc_lp_wq", base_vha->host_no);
-		ha->dpc_lp_wq = create_singlethread_workqueue(wq_name);
+		ha->dpc_lp_wq =
+			alloc_ordered_workqueue("%s", WQ_MEM_RECLAIM, wq_name);
 		INIT_WORK(&ha->idc_aen, qla83xx_service_idc_aen);
 
 		sprintf(wq_name, "qla2xxx_%lu_dpc_hp_wq", base_vha->host_no);
-		ha->dpc_hp_wq = create_singlethread_workqueue(wq_name);
+		ha->dpc_hp_wq =
+			alloc_ordered_workqueue("%s", WQ_MEM_RECLAIM, wq_name);
 		INIT_WORK(&ha->nic_core_reset, qla83xx_nic_core_reset_work);
 		INIT_WORK(&ha->idc_state_handler,
 		    qla83xx_idc_state_handler_work);

--- a/qla2x00t-32gbit/qla_target.c
+++ b/qla2x00t-32gbit/qla_target.c
@@ -23,7 +23,6 @@
 #include <linux/delay.h>
 #include <linux/list.h>
 #include <linux/workqueue.h>
-#include <asm/unaligned.h>
 #include <scsi/scsi.h>
 #include <scsi/scsi_host.h>
 #include <scsi/scsi_tcq.h>

--- a/qla2x00t-32gbit/qla_target.h
+++ b/qla2x00t-32gbit/qla_target.h
@@ -19,8 +19,6 @@
 #ifndef __QLA_TARGET_H
 #define __QLA_TARGET_H
 
-#include <linux/version.h>
-#include <asm/unaligned.h>
 #include "qla_def.h"
 #include "qla_dsd.h"
 

--- a/qla2x00t/qla2x00-target/qla2x00t.c
+++ b/qla2x00t/qla2x00-target/qla2x00t.c
@@ -32,7 +32,6 @@
 #include <linux/delay.h>
 #include <linux/list.h>
 #include <linux/workqueue.h>
-#include <asm/unaligned.h>
 
 #ifdef INSIDE_KERNEL_TREE
 #include <scst/scst.h>

--- a/scripts/checkpatch
+++ b/scripts/checkpatch
@@ -1,13 +1,17 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ignore=(
-    CONSTANT_COMPARISON
-    LINUX_VERSION_CODE
-    LONG_LINE
-    LONG_LINE_COMMENT
-    LONG_LINE_STRING
-    RETURN_VOID
-    SPDX_LICENSE_TAG
-    SYMBOLIC_PERMS
+	CONSTANT_COMPARISON
+	LINUX_VERSION_CODE
+	LONG_LINE
+	LONG_LINE_COMMENT
+	LONG_LINE_STRING
+	RETURN_VOID
+	SPDX_LICENSE_TAG
+	SYMBOLIC_PERMS
 )
-../linux-kernel/scripts/checkpatch.pl -f --show-types --ignore="$(echo "${ignore[@]}" | sed 's/ /,/g')" $(list-source-files | grep -vE '^debian/|^fcst/linux-patches|patch$|pdf$|png$|^iscsi-scst/usr|^qla|^scripts/|^scstadmin/|^usr/|^www/') | sed 's/^#[0-9]*: FILE: \(.*\):/\1:1:/'
+ignore_str=${ignore[*]}
+
+src_files=$(list-source-files | grep -vE '^debian/|^fcst/linux-patches|patch$|pdf$|png$|^iscsi-scst/usr|^qla|^scripts/|^scstadmin/|^usr/|^www/')
+
+../linux-kernel/scripts/checkpatch.pl -f --show-types --strict --ignore="${ignore_str// /,}" $src_files | sed 's/^#[0-9]*: FILE: \(.*\):/\1:1:/'

--- a/scripts/checkpatch
+++ b/scripts/checkpatch
@@ -1,17 +1,22 @@
 #!/usr/bin/env bash
 
+set -e
+
+scriptpath=${CHECKPATCH_PATH:-/lib/modules/$(uname -r)/build/scripts}
+
 ignore=(
-	CONSTANT_COMPARISON
-	LINUX_VERSION_CODE
-	LONG_LINE
-	LONG_LINE_COMMENT
-	LONG_LINE_STRING
-	RETURN_VOID
+	MISSING_SIGN_OFF
+	EMAIL_SUBJECT
+	UNKNOWN_COMMIT_ID
+	NO_AUTHOR_SIGN_OFF
+	COMMIT_LOG_USE_LINK
+	BAD_REPORTED_BY_LINK
+	FILE_PATH_CHANGES
 	SPDX_LICENSE_TAG
-	SYMBOLIC_PERMS
+	LINUX_VERSION_CODE
+	CONSTANT_COMPARISON
+	NEW_TYPEDEFS
 )
 ignore_str=${ignore[*]}
 
-src_files=$(list-source-files | grep -vE '^debian/|^fcst/linux-patches|patch$|pdf$|png$|^iscsi-scst/usr|^qla|^scripts/|^scstadmin/|^usr/|^www/')
-
-../linux-kernel/scripts/checkpatch.pl -f --show-types --strict --ignore="${ignore_str// /,}" $src_files | sed 's/^#[0-9]*: FILE: \(.*\):/\1:1:/'
+${scriptpath}/checkpatch.pl --no-tree --show-types --strict --ignore="${ignore_str// /,}" $@

--- a/scripts/checkpatch_commits
+++ b/scripts/checkpatch_commits
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+rootdir=$(readlink -f $(dirname $0)/..)
+scriptsdir=${rootdir}/scripts
+base_commit=${1:-master}
+
+commits=$(cd ${rootdir} && git log --pretty=format:"%h" ${base_commit}..HEAD)
+err=0
+
+for commit in $commits; do
+	echo "Running checkpatch for commit $commit"
+	echo -e "========================================\n"
+
+	(cd ${rootdir} &&
+		git format-patch -1 --stdout $commit | ${scriptsdir}/checkpatch -) || err=1
+	echo -e "\n"
+done
+
+exit $err

--- a/scripts/checkpatch_diff
+++ b/scripts/checkpatch_diff
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+rootdir=$(readlink -f $(dirname $0)/..)
+scriptsdir=${rootdir}/scripts
+base_commit=${1:-master}
+
+err=0
+
+(cd ${rootdir} && git diff ${base_commit} | ${scriptsdir}/checkpatch -) || err=1
+
+exit $err

--- a/scripts/checkpatch_scan
+++ b/scripts/checkpatch_scan
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+rootdir=$(readlink -f $(dirname $0)/..)
+scriptsdir=${rootdir}/scripts
+outputfile=checkpatch.out
+
+src_files=$(${scriptsdir}/list-source-files ${rootdir} | \
+	grep -vE '^debian/|^fcst/linux-patches|patch$|pdf$|png$|^iscsi-scst/usr|^qla|^scripts/|^scstadmin/|^usr/|^www/' | \
+	while read -r filename; do echo "${rootdir}/$filename"; done)
+
+${scriptsdir}/checkpatch -f $src_files 1> ${outputfile} || true
+
+errors=$(grep -c '^ERROR' "${outputfile}")
+warnings=$(grep -c '^WARNING' "${outputfile}")
+checks=$(grep -c '^CHECK' "${outputfile}")
+
+echo "${errors} errors / ${warnings} warnings / ${checks} checks."
+
+grep -E '^WARNING|^ERROR|^CHECK' "${outputfile}" |
+	sort |
+	sed 's/^CHECK:CAMELCASE: Avoid CamelCase:.*/CHECK:CAMELCASE Avoid CamelCase/' |
+	uniq -c

--- a/scripts/run-regression-tests
+++ b/scripts/run-regression-tests
@@ -231,7 +231,7 @@ function run_checkpatch  {
     if [ "${multiple_patches}" = "false" ]; then
       echo "Running checkpatch on the SCST kernel patch ..."
       ( cd "${outputdir}/linux-$1" \
-        && scripts/checkpatch.pl --no-tree --no-signoff - < "${patchfile}" &> "${outputfile}")
+        && scripts/checkpatch.pl --no-tree --no-signoff --strict - < "${patchfile}" &> "${outputfile}")
     else
       echo "Running checkpatch on the SCST kernel patches ..."
       rm -f "${outputfile}"
@@ -239,17 +239,21 @@ function run_checkpatch  {
         && for p in "${outputdir}/${patchdir}"/*
            do
              echo "==== $p" >>"${outputfile}"
-             scripts/checkpatch.pl --no-tree --no-signoff - < "$p" >> "${outputfile}" 2>&1
+             scripts/checkpatch.pl --no-tree --no-signoff --strict - < "$p" >> "${outputfile}" 2>&1
            done
       )
     fi
+
     errors=$(grep -c '^ERROR' "${outputfile}")
     warnings=$(grep -c '^WARNING' "${outputfile}")
-    echo "${errors} errors / ${warnings} warnings."
-    grep -E '^WARNING|^ERROR' "${outputfile}" |
+    checks=$(grep -c '^CHECK' "${outputfile}")
+
+    echo "${errors} errors / ${warnings} warnings / ${checks} checks."
+
+    grep -E '^WARNING|^ERROR|^CHECK' "${outputfile}" |
       sort |
       grep -v 'WARNING: missing space after return type' |
-      sed 's/^WARNING: Avoid CamelCase:.*/WARNING: Avoid CamelCase/' |
+      sed 's/^CHECK: Avoid CamelCase:.*/CHECK: Avoid CamelCase/' |
       uniq -c
   else
     echo "Skipping checkpatch step for kernel $1."

--- a/scst/include/backport.h
+++ b/scst/include/backport.h
@@ -288,7 +288,9 @@ static inline void blkdev_put_backport(struct block_device *bdev, void *holder)
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 7, 0) &&			\
 	(LINUX_VERSION_CODE >> 8 != KERNEL_VERSION(6, 6, 0) >> 8 ||	\
-	 LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 23))
+	 LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 23)) &&		\
+	(!defined(RHEL_RELEASE_CODE) ||					\
+	 RHEL_RELEASE_CODE -0 < RHEL_RELEASE_VERSION(9, 5))
 /*
  * See also commit e719b4d15674 ("block: Provide bdev_open_* functions") # v6.7, v6.6.23.
  */

--- a/scst/include/backport.h
+++ b/scst/include/backport.h
@@ -49,7 +49,11 @@
 #include <scsi/scsi_eh.h>	/* scsi_build_sense_buffer() */
 struct scsi_target;
 #include <scsi/scsi_transport_fc.h> /* struct bsg_job */
-#include <asm/unaligned.h>	/* get_unaligned_be64() */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+#include <asm/unaligned.h>
+#else
+#include <linux/unaligned.h>
+#endif
 
 /* <asm-generic/barrier.h> */
 

--- a/scst/include/scst.h
+++ b/scst/include/scst.h
@@ -39,10 +39,14 @@
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
 #include <linux/sched/signal.h>
 #endif
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+#include <asm/unaligned.h>
+#else
+#include <linux/unaligned.h>
+#endif
 #include <linux/wait.h>
 #include <linux/cpumask.h>
 #include <linux/dlm.h>
-#include <asm/unaligned.h>
 
 #if 0 /* Let's disable it for now to see if users will complain about it */
 #define CONFIG_SCST_PER_DEVICE_CMD_COUNT_LIMIT

--- a/scst/src/dev_handlers/scst_cdrom.c
+++ b/scst/src/dev_handlers/scst_cdrom.c
@@ -21,7 +21,6 @@
 #include <linux/cdrom.h>
 #include <scsi/scsi_host.h>
 #include <linux/slab.h>
-#include <asm/unaligned.h>
 
 #define LOG_PREFIX	"dev_cdrom"
 

--- a/scst/src/dev_handlers/scst_disk.c
+++ b/scst/src/dev_handlers/scst_disk.c
@@ -26,7 +26,6 @@
 #include <linux/blkdev.h>
 #include <scsi/scsi_host.h>
 #include <linux/slab.h>
-#include <asm/unaligned.h>
 
 #define LOG_PREFIX           "dev_disk"
 

--- a/scst/src/dev_handlers/scst_modisk.c
+++ b/scst/src/dev_handlers/scst_modisk.c
@@ -25,7 +25,6 @@
 #include <linux/init.h>
 #include <scsi/scsi_host.h>
 #include <linux/slab.h>
-#include <asm/unaligned.h>
 
 #define LOG_PREFIX             "dev_modisk"
 

--- a/scst/src/dev_handlers/scst_tape.c
+++ b/scst/src/dev_handlers/scst_tape.c
@@ -173,7 +173,9 @@ static int tape_attach(struct scst_device *dev)
 			     ((dev->scsi_dev->scsi_level <= SCSI_2) ?
 			      ((dev->scsi_dev->lun << 5) & 0xe0) : 0),
 			     0 /* Mode Page 0 */,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0) ||		\
+	(defined(RHEL_RELEASE_CODE) &&				\
+	 RHEL_RELEASE_CODE -0 >= RHEL_RELEASE_VERSION(9, 5))
 			     0 /* Sub Page */,
 #endif
 			     buffer, buffer_size,

--- a/scst/src/dev_handlers/scst_tape.c
+++ b/scst/src/dev_handlers/scst_tape.c
@@ -25,7 +25,6 @@
 #include <linux/init.h>
 #include <scsi/scsi_host.h>
 #include <linux/slab.h>
-#include <asm/unaligned.h>
 
 #define LOG_PREFIX           "dev_tape"
 

--- a/scst/src/dev_handlers/scst_vdisk.c
+++ b/scst/src/dev_handlers/scst_vdisk.c
@@ -50,7 +50,6 @@
 #include <linux/delay.h>
 #include <linux/namei.h>
 #include <asm/div64.h>
-#include <asm/unaligned.h>
 #include <linux/slab.h>
 #include <linux/bio.h>
 #include <linux/crc32c.h>

--- a/scst/src/scst_copy_mgr.c
+++ b/scst/src/scst_copy_mgr.c
@@ -8,7 +8,6 @@
 #include <linux/types.h>
 #include <linux/init.h>
 #include <linux/slab.h>
-#include <asm/unaligned.h>
 #include <linux/delay.h>
 
 #ifdef INSIDE_KERNEL_TREE
@@ -3898,4 +3897,3 @@ void __exit scst_cm_exit(void)
 	TRACE_EXIT();
 	return;
 }
-

--- a/scst/src/scst_dlm.c
+++ b/scst/src/scst_dlm.c
@@ -1480,7 +1480,7 @@ create_st_wq(const char *fmt, ...)
 	name = kvasprintf(GFP_KERNEL, fmt, ap);
 	va_end(ap);
 	if (name)
-		wq = create_singlethread_workqueue(name);
+		wq = alloc_ordered_workqueue("%s", WQ_MEM_RECLAIM, name);
 	kfree(name);
 	return wq;
 }

--- a/scst/src/scst_lib.c
+++ b/scst/src/scst_lib.c
@@ -32,7 +32,6 @@
 #include <linux/ctype.h>
 #include <linux/delay.h>
 #include <linux/vmalloc.h>
-#include <asm/unaligned.h>
 #include <asm/checksum.h>
 #ifndef INSIDE_KERNEL_TREE
 #include <linux/version.h>

--- a/scst/src/scst_lib.c
+++ b/scst/src/scst_lib.c
@@ -6083,7 +6083,9 @@ int scst_open_bdev_by_path(const char *path, blk_mode_t mode, void *holder,
 			   const struct blk_holder_ops *hops,
 			   struct scst_bdev_descriptor *bdev_desc)
 {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 9, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 9, 0) &&		\
+	(!defined(RHEL_RELEASE_CODE) ||				\
+	 RHEL_RELEASE_CODE -0 < RHEL_RELEASE_VERSION(9, 5))
 	struct bdev_handle *bdev_handle;
 
 	bdev_handle = bdev_open_by_path(path, mode, holder, hops);
@@ -6109,7 +6111,9 @@ EXPORT_SYMBOL(scst_open_bdev_by_path);
 
 void scst_release_bdev(struct scst_bdev_descriptor *bdev_desc)
 {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 9, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 9, 0) &&		\
+	(!defined(RHEL_RELEASE_CODE) ||				\
+	 RHEL_RELEASE_CODE -0 < RHEL_RELEASE_VERSION(9, 5))
 	struct bdev_handle *bdev_handle = bdev_desc->priv;
 
 	if (bdev_handle)

--- a/scst/src/scst_pres.c
+++ b/scst/src/scst_pres.c
@@ -40,7 +40,6 @@
 #include <linux/version.h>
 #endif
 #include <linux/vmalloc.h>
-#include <asm/unaligned.h>
 
 #ifdef INSIDE_KERNEL_TREE
 #include <scst/scst.h>

--- a/scst/src/scst_tg.c
+++ b/scst/src/scst_tg.c
@@ -18,7 +18,6 @@
 #include <linux/moduleparam.h>
 #include <linux/delay.h>
 #include <linux/kmod.h>
-#include <asm/unaligned.h>
 #ifdef INSIDE_KERNEL_TREE
 #include <scst/scst.h>
 #include <scst/scst_event.h>

--- a/scst_local/scst_local.c
+++ b/scst_local/scst_local.c
@@ -1791,7 +1791,7 @@ static int __init scst_local_init(void)
 	 * We don't expect much work on this queue, so only create a
 	 * single thread workqueue rather than one on each core.
 	 */
-	aen_workqueue = create_singlethread_workqueue("scstlclaen");
+	aen_workqueue = alloc_ordered_workqueue("scstlclaen", WQ_MEM_RECLAIM);
 	if (!aen_workqueue) {
 		PRINT_ERROR("%s", "Unable to create scst_local workqueue");
 		goto tgt_templ_unreg;


### PR DESCRIPTION
Previously rebased `master` on upstream `master`. Now rebase `truenas-3.9.0-pre` on `master`.

This will pickup recent upstream changes including: "scst: Port to Linux kernel v6.12" (256d695)

```
git clone https://github.com/truenas/scst.git
cd scst
git branch
git checkout -b rebase_on_master
git log
git rebase -i origin/master
git diff origin/master...rebase_on_master
git diff rebase_on_master...truenas-3.9.0-pre
git diff truenas-3.9.0-pre...rebase_on_master
git push --set-upstream origin rebase_on_master
```

CI custom build [here](http://jenkins.eng.ixsystems.net:8080/job/master/job/custom/721/) and corresponding CI run [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/1818/).