### PR TITLE
Revert "Do not auto-load isert_scst kernel module"

### DIFF
--- a/scstadmin/init.d/scst
+++ b/scstadmin/init.d/scst
@@ -158,7 +158,7 @@ parse_scst_conf() {
             x86_64|i686)
                 SCST_OPT_MODULES="crc32c-intel $SCST_OPT_MODULES";;
         esac
-        SCST_OPT_MODULES="crc32c $SCST_OPT_MODULES"
+        SCST_OPT_MODULES="crc32c isert_scst $SCST_OPT_MODULES"
         SCST_DAEMONS="$(which iscsi-scstd) $SCST_DAEMONS"
     fi
 }


### PR DESCRIPTION
This reverts commit 1dec3833ca82249c7f73c90aae7545b2a72a8063. I added the wrong label 🤦‍♂️ 