### PR TITLE
NAS-131279 / None / Use pyscstadmin in scst init script

### DIFF
--- a/scstadmin/init.d/scst
+++ b/scstadmin/init.d/scst
@@ -206,6 +206,10 @@ unload_scst() {
     # Clear the config in case unloading failed or SCST has been built into the
     # kernel
     if [ -e /sys/module/scst ]; then
+        if [ -f /etc/scst.direct ]; then
+            pyscstadmin -clear_config >/dev/null 2>&1
+            return 0
+        fi
         scstadmin -noprompt -force -clear_config >/dev/null 2>&1
     fi
 
@@ -247,6 +251,18 @@ start_scst() {
         done
 
         if [ -f $SCST_CFG ]; then
+            if [ -f /etc/scst.direct ]; then
+                pyscstadmin -clear_config >/dev/null 2>&1
+                tmpout=/tmp/scstadmin-output-$$
+                if pyscstadmin -config $SCST_CFG -suspend 5 >$tmpout 2>&1; then
+                    rm -f $tmpout
+                    return 0
+                else
+                cat $tmpout
+                rm -f $tmpout
+                fi
+                # Fall thru to retry with scstadmin
+            fi
             scstadmin -force -noprompt -clear_config >/dev/null 2>&1
             tmpout=/tmp/scstadmin-output-$$
             if scstadmin -config $SCST_CFG >$tmpout 2>&1; then


### PR DESCRIPTION
Use `pyscstadmin` rather than `scstadmin` in the `init` script.

Requires corresponding middlewared PR to activate.


----
Passing CI [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/sharing_protocols_tests/603/) (and [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/6234/)).