### PR TITLE
NAS-140096 / 26.0.0-BETA.1 / iscsi-scst: Fix performance regression

### DIFF
--- a/iscsi-scst/kernel/iscsi.c
+++ b/iscsi-scst/kernel/iscsi.c
@@ -4108,7 +4108,7 @@ create:
 	if (dedicated) {
 		count = 1;
 	} else if (!cpu_mask) {
-		count = blk_mq_num_online_queues(2);
+		count = max_t(int, blk_mq_num_online_queues(0), 2);
 	} else {
 		count = 0;
 		for_each_cpu(i, cpu_mask)


### PR DESCRIPTION
A [change](https://github.com/SCST-project/scst/pull/316/changes/5ba657f81a8472d27af1e9b642359b05fbfabbef) in `iscsi_threads_pool_get` changed 2 from being the minimum `count` to the maximum.  Rectify.