### PR TITLE
NAS-134637 / 25.10.2.2 / Backport Fibre Channel shutdown fixes

### DIFF
--- a/qla2x00t-32gbit/qla2x00-target/scst_qla2xxx.c
+++ b/qla2x00t-32gbit/qla2x00-target/scst_qla2xxx.c
@@ -728,7 +728,23 @@ static void sqa_qla2xxx_free_session(struct fc_port *fcport)
 		DECLARE_COMPLETION_ONSTACK(c);
 
 		fcport->unreg_done = &c;
-		scst_unregister_session(scst_sess, 1, sqa_free_session_done);
+		/*
+		 * Use wait=0 (async) to avoid a severe stall under concurrent
+		 * session teardown.  With wait=1 the workqueue thread blocks
+		 * inside scst_unregister_session() until
+		 * scst_free_session_callback() fires.  That callback cannot be
+		 * scheduled until the TM thread processes SCST_UNREG_SESS_TM,
+		 * but the TM thread is blocked on scst_mutex which the global
+		 * management thread holds during concurrent session teardown
+		 * (scst_sess_free_tgt_devs -> synchronize_rcu()).  Under load
+		 * this stall exceeds the hung-task timeout.  With wait=0 the
+		 * workqueue thread is released immediately; we wait only on
+		 * fcport->unreg_done, signalled by sqa_free_session_done() at
+		 * a point where scst_mutex is not held.
+		 * See also: iscsi-scst session_free() which carries a similar
+		 * warning.
+		 */
+		scst_unregister_session(scst_sess, 0, sqa_free_session_done);
 		wait_for_completion(&c);
 	}
 

--- a/scstadmin/init.d/scst
+++ b/scstadmin/init.d/scst
@@ -190,7 +190,7 @@ unload_scst() {
     # seconds.
     unload_kmod isert_scst 90 || echo "Unloading isert_scst failed"
 
-    for m in isert_scst iscsi_scst fcst ib_srpt qla2xxx_scst qla2x00tgt \
+    for m in isert_scst iscsi_scst fcst ib_srpt qla2x00tgt qla2xxx_scst \
 	     scst_local scst_disk scst_raid scst_tape scst_user scst_changer \
 	     scst_cdrom scst_vdisk scst_modisk scst_processor scst; do
 	unload_kmod "$m" 30


### PR DESCRIPTION
Backport two fixes to 25.10.2.2
- qla2xxx: fix session free stall by using scst_unregister_session wait=0
- scstadmin/init.d: unload qla2x00tgt before qla2xxx_scst