### PR TITLE
NAS-140407 / 25.10.2.2 / scst: add async_lun_replace to defer tgt_dev cleanup after LUN replace

### DIFF
--- a/scst/src/scst_lib.c
+++ b/scst/src/scst_lib.c
@@ -4771,6 +4771,29 @@ out:
 	return res;
 }
 
+struct scst_async_repl_work {
+	struct work_struct work;
+	struct list_head tgt_dev_list;
+};
+
+static void scst_async_repl_work_fn(struct work_struct *work)
+{
+	struct scst_async_repl_work *w =
+		container_of(work, struct scst_async_repl_work, work);
+	struct scst_tgt_dev *tgt_dev, *tt;
+
+	scst_wait_for_tgt_devs(&w->tgt_dev_list);
+	synchronize_rcu();
+
+	mutex_lock(&scst_mutex);
+	list_for_each_entry_safe(tgt_dev, tt, &w->tgt_dev_list,
+				 extra_tgt_dev_list_entry)
+		scst_free_tgt_dev(tgt_dev);
+	mutex_unlock(&scst_mutex);
+
+	kfree(w);
+}
+
 /* Either add or replace a LUN according to flags argument */
 int scst_acg_repl_lun(struct scst_acg *acg, struct kobject *parent,
 		      struct scst_device *dev, uint64_t lun,
@@ -4805,13 +4828,30 @@ int scst_acg_repl_lun(struct scst_acg *acg, struct kobject *parent,
 	}
 	mutex_unlock(&scst_mutex);
 
+	if (acg_dev && READ_ONCE(scst_async_lun_replace)) {
+		struct scst_async_repl_work *w =
+			kzalloc(sizeof(*w), GFP_KERNEL);
+		if (w) {
+			INIT_WORK(&w->work, scst_async_repl_work_fn);
+			INIT_LIST_HEAD(&w->tgt_dev_list);
+			list_splice_init(&tgt_dev_list, &w->tgt_dev_list);
+			schedule_work(&w->work);
+			goto relock;
+		}
+		/* fall back to synchronous path on allocation failure */
+	}
+
 	scst_wait_for_tgt_devs(&tgt_dev_list);
 	synchronize_rcu();
 
 	mutex_lock(&scst_mutex);
 	list_for_each_entry_safe(tgt_dev, tt, &tgt_dev_list, extra_tgt_dev_list_entry)
 		scst_free_tgt_dev(tgt_dev);
+	goto free_acg_dev;
 
+relock:
+	mutex_lock(&scst_mutex);
+free_acg_dev:
 	if (acg_dev)
 		scst_free_acg_dev(acg_dev);
 

--- a/scst/src/scst_main.c
+++ b/scst/src/scst_main.c
@@ -190,6 +190,11 @@ module_param_named(auto_cm_assignment, scst_auto_cm_assignment, bool,
 		   S_IWUSR | S_IRUGO);
 MODULE_PARM_DESC(auto_cm_assignment, "Enables the copy managers auto registration. (default: true)");
 
+bool scst_async_lun_replace;
+module_param_named(async_lun_replace, scst_async_lun_replace, bool, 0644);
+MODULE_PARM_DESC(async_lun_replace,
+		 "If enabled, LUN replace operations do not wait synchronously for in-flight commands on the old tgt_dev to drain; cleanup is deferred to a workqueue. (default: false)");
+
 struct scst_dev_type scst_null_devtype = {
 	.name = "none",
 	.threads_num = -1,

--- a/scst/src/scst_priv.h
+++ b/scst/src/scst_priv.h
@@ -154,6 +154,7 @@ extern unsigned int scst_max_dev_cmd_mem;
 
 extern bool scst_forcibly_close_sessions;
 extern bool scst_auto_cm_assignment;
+extern bool scst_async_lun_replace;
 
 extern mempool_t *scst_mgmt_mempool;
 extern mempool_t *scst_mgmt_stub_mempool;

--- a/scst/src/scst_sysfs.c
+++ b/scst/src/scst_sysfs.c
@@ -7156,6 +7156,30 @@ static struct kobj_attribute scst_measure_latency_attr =
 	       scst_measure_latency_show,
 	       scst_measure_latency_store);
 
+static ssize_t scst_async_lun_replace_show(struct kobject *kobj,
+					   struct kobj_attribute *attr,
+					   char *buf)
+{
+	return sysfs_emit(buf, "%d\n", READ_ONCE(scst_async_lun_replace) ? 1 : 0);
+}
+
+static ssize_t scst_async_lun_replace_store(struct kobject *kobj,
+					    struct kobj_attribute *attr,
+					    const char *buf, size_t count)
+{
+	int val;
+
+	if (kstrtoint(buf, 0, &val))
+		return -EINVAL;
+	WRITE_ONCE(scst_async_lun_replace, val != 0);
+	return count;
+}
+
+static struct kobj_attribute scst_async_lun_replace_attr =
+	__ATTR(async_lun_replace, 0644,
+	       scst_async_lun_replace_show,
+	       scst_async_lun_replace_store);
+
 static ssize_t scst_threads_show(struct kobject *kobj,
 	struct kobj_attribute *attr, char *buf)
 {
@@ -7763,6 +7787,7 @@ static struct kobj_attribute scst_cluster_name_attr =
 
 static struct attribute *scst_sysfs_root_def_attrs[] = {
 	&scst_measure_latency_attr.attr,
+	&scst_async_lun_replace_attr.attr,
 	&scst_threads_attr.attr,
 	&scst_setup_id_attr.attr,
 	&scst_max_tasklet_cmd_attr.attr,


### PR DESCRIPTION
scst_acg_repl_lun calls scst_wait_for_tgt_devs after removing the old tgt_devs, polling tgt_dev_cmd_count every 100ms until all in-flight commands on the old device drain.  The sysfs write to luns/mgmt does not return until this completes.

In HA failover configurations the old tgt_devs are backed by a passthrough device (dev_disk) whose underlying iSCSI session has already died.  Commands dispatched to it before the session dropped are stuck in kernel iSCSI error recovery for up to replacement_timeout (default 120s), blocking the LUN replace for the entire window and causing the failover to miss its timeout.

Add a bool module parameter async_lun_replace (default false, also writable via /sys/kernel/scst_tgt/async_lun_replace).  When enabled, scst_acg_repl_lun transfers the removed tgt_devs to a kzalloc'd work struct and schedules it on system_wq, returning immediately.  The work function runs the original scst_wait_for_tgt_devs + synchronize_rcu + scst_free_tgt_dev sequence asynchronously.  After __scst_acg_del_lun the old tgt_devs are unreachable via any lookup path; only in-flight commands hold references via cmd->tgt_dev, so deferring the free until tgt_dev_cmd_count reaches zero is safe.  Falls back to synchronous behavior if kzalloc fails.