### PR TITLE
NAS-140342 / 26.0.0-BETA.1 / iscsi-scstd: Return SVC_UNAVAILABLE while logins are suspended

### DIFF
--- a/iscsi-scst/usr/iscsi_scstd.c
+++ b/iscsi-scst/usr/iscsi_scstd.c
@@ -858,6 +858,18 @@ static void init_max_params(void)
 	return;
 }
 
+static void suspend_logins(int sig)
+{
+	(void)sig;
+	logins_suspended = 1;
+}
+
+static void resume_logins(int sig)
+{
+	(void)sig;
+	logins_suspended = 0;
+}
+
 int main(int argc, char **argv)
 {
 	int ch, longindex;
@@ -881,6 +893,14 @@ int main(int argc, char **argv)
 	 */
 	struct sigaction act = (struct sigaction) { .sa_handler = SIG_IGN };
 	int rc = sigaction(SIGPIPE, &act, NULL);
+	assert(rc == 0);
+
+	act = (struct sigaction) { .sa_handler = suspend_logins };
+	rc = sigaction(SIGUSR1, &act, NULL);
+	assert(rc == 0);
+
+	act = (struct sigaction) { .sa_handler = resume_logins };
+	rc = sigaction(SIGUSR2, &act, NULL);
 	assert(rc == 0);
 
 	while ((ch = getopt_long(argc, argv, "c:fd:s:u:g:a:p:vh", long_options, &longindex)) >= 0) {

--- a/iscsi-scst/usr/iscsid.c
+++ b/iscsi-scst/usr/iscsid.c
@@ -28,6 +28,7 @@
 
 int iscsi_enabled;
 char *internal_portal;
+int logins_suspended;
 
 static u32 ttt;
 
@@ -808,6 +809,13 @@ static void login_start(struct connection *conn)
 	if (conn->initiator == NULL) {
 		log_error("Unable to duplicate initiator's name %s", name);
 		login_rsp_tgt_err(conn, ISCSI_STATUS_NO_RESOURCES);
+		return;
+	}
+
+	if (logins_suspended) {
+		log_info("Initiator %s login rejected: service temporarily unavailable",
+			 conn->initiator);
+		login_rsp_tgt_err(conn, ISCSI_STATUS_SVC_UNAVAILABLE);
 		return;
 	}
 

--- a/iscsi-scst/usr/iscsid.h
+++ b/iscsi-scst/usr/iscsid.h
@@ -263,6 +263,7 @@ extern const char *get_error_str(int error);
 /* iscsid.c */
 extern int iscsi_enabled;
 extern char *internal_portal;
+extern int logins_suspended;
 
 extern int cmnd_execute(struct connection *conn);
 extern void cmnd_finish(struct connection *conn);


### PR DESCRIPTION
```
git checkout release/26.0.0-BETA.1
git checkout -b NAS-140342-26.0.0-BETA.1
git rebase -i origin/truenas-3.11.0-pre
```