### PR TITLE
NAS-140832 / 27.0.0-BETA.1 / scst: set PKG_BUILD_MODE before module compilation in install target

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -72,6 +72,7 @@ build-arch: build
 install:
 	[ -n "$(VERSION)" ] &&						\
 	dh_testdir &&							\
+	make $(PKG_BUILD_MODE) &&					\
 	export PREFIX=/usr &&						\
 	export DESTDIR="$(DESTDIR)" &&					\
 	export BUILD_2X_MODULE=y &&					\


### PR DESCRIPTION
The install target called make $(PKG_BUILD_MODE) only after the module build loop, so the build_mode file (wiped by clean) was recreated with the empty/debug default before any modules were compiled. Move the call to immediately after dh_testdir so the correct build mode is established before make -C scst install triggers compilation.