### PR TITLE
NAS-141162 / 26.0.0-RC.1 / scst: skip kmalloc_obj() macros when kernel provides them (by ixhamza)

### DIFF
--- a/scst/include/backport.h
+++ b/scst/include/backport.h
@@ -1721,7 +1721,25 @@ static inline struct kmem_cache *kmem_cache_create_usercopy(const char *name,
 /*
  * See also commit 2932ba8d9c99 ("slab: Introduce kmalloc_obj() and family") # v7.0.
  * See also commit e4c8b46b924e ("slab: Introduce kmalloc_flex() and family") # v7.0.
+ *
+ * Stable kernels that picked up commit 3bf5e19c804d ("slab: Introduce
+ * kmalloc_obj() and family") provide these macros with a fixed GFP argument
+ * and cannot serve SCST's variadic default-GFP call sites, so drop the
+ * kernel-supplied definitions when present and let SCST's versions win.
+ * The _flex family and default_gfp() helper are SCST-only and are unaffected.
  */
+#ifdef kmalloc_obj
+#undef __alloc_objs
+#undef kmalloc_obj
+#undef kmalloc_objs
+#undef kzalloc_obj
+#undef kzalloc_objs
+#undef kvmalloc_obj
+#undef kvmalloc_objs
+#undef kvzalloc_obj
+#undef kvzalloc_objs
+#endif
+
 #define __alloc_objs(KMALLOC, GFP, TYPE, COUNT)				\
 ({									\
 	const size_t __obj_size = size_mul(sizeof(TYPE), COUNT);	\


### PR DESCRIPTION
Stable kernels that pulled in commit [3bf5e19c804d ("slab: Introduce kmalloc_obj() and family")](https://github.com/truenas/linux/commit/3bf5e19c804d) collide with SCST's identically-named macros in backport.h:

> backport.h:1741:9: error: "kmalloc_obj" redefined [-Werror]
> slab.h:993:9: note: this is the location of the previous definition

The kernel's macro requires GFP as an explicit argument. SCST's is variadic and defaults to `GFP_KERNEL`. About 80 SCST call sites omit GFP and depend on that default, so the kernel's macros cannot replace SCST's. Undefine the kernel-supplied macros when present and let SCST's versions take effect.

On older kernels the `#ifdef kmalloc_obj` guard is false, so the block is skipped and behavior is unchanged.

Related kernel PR: https://github.com/truenas/linux/pull/280

### Testing
- Failing build (before fix): http://jenkins.eng.ixsystems.net:8080/job/custom_build/job/build/217/artifact/logs/packages/scst.log
- Passing build (after fix): http://jenkins.eng.ixsystems.net:8080/job/custom_build/job/build/221/console

Original PR: https://github.com/truenas/scst/pull/92
