### PR TITLE
NAS-142003 / 26.0.0-RC.1 / fix kernel BUG in scst_lib.c:7103 (by yocalebo)

### DIFF
--- a/scst/src/scst_lib.c
+++ b/scst/src/scst_lib.c
@@ -7063,12 +7063,11 @@ static void scst_cwr_write_cmd_finished(struct scst_cmd *cmd)
 
 		TRACE_DBG("WRITE cmd %p (cwr cmd %p) finished not successfully",
 			cmd, cwr_cmd);
-		sBUG_ON(cmd->resp_data_len != 0);
-		if (cmd->status == SAM_STAT_CHECK_CONDITION)
+		if (cmd->status == SAM_STAT_CHECK_CONDITION &&
+		    scst_sense_valid(cmd->sense))
 			rc = scst_set_cmd_error_sense(cwr_cmd, cmd->sense,
 				cmd->sense_valid_len);
 		else {
-			sBUG_ON(cmd->sense != NULL);
 			rc = scst_set_cmd_error_status(cwr_cmd, cmd->status);
 		}
 		if (rc != 0) {
@@ -7100,12 +7099,11 @@ static void scst_cwr_read_cmd_finished(struct scst_cmd *cmd)
 	if (cmd->status != 0) {
 		TRACE_DBG("Read cmd %p (cwr cmd %p) finished not successfully",
 			cmd, cwr_cmd);
-		sBUG_ON(cmd->resp_data_len != 0);
-		if (cmd->status == SAM_STAT_CHECK_CONDITION)
+		if (cmd->status == SAM_STAT_CHECK_CONDITION &&
+		    scst_sense_valid(cmd->sense))
 			rc = scst_set_cmd_error_sense(cwr_cmd, cmd->sense,
 				cmd->sense_valid_len);
 		else {
-			sBUG_ON(cmd->sense != NULL);
 			rc = scst_set_cmd_error_status(cwr_cmd, cmd->status);
 		}
 		if (rc != 0) {


### PR DESCRIPTION
FC ALUA is panicking and boot looping the standby controller on 2 different customers. One of them we were able to get the stack trace on.
```
[269.974364] kernel BUG at /dpkg-src/scst/src/scst_lib.c:7104!
[269.981052] Oops: invalid opcode: 0000 [#1] PREEMPT SMP NOPTI
[269.987668] CPU: 4 UID: 0 PID: 6970 Comm: 18:0:0:31_0 Tainted: POE 6.12.91-production+truenas #1
[269.998712] Tainted: [P]=PROPRIETARY_MODULE, [O]=OOT_MODULE, [E]=UNSIGNED_MODULE
[270.006949] Hardware name: iXsystems TRUENAS-M40-HA/X11SPi-TF, BIOS 3.3.V6 03/16/2021
[270.015620] RIP: 0010:scst_cwr_read_cmd_finished+0x843/0x860 [scst]
[270.022838] Code: 24 80 3d 57 10 03 00 00 0f 85 60 fd ff ff 89 c6 48 c7 c7 30 75 c5 c1 c6 05 41 10 03 00 01 e8 54 b5 1b c8 0f 0b e9 44 fd ff ff <0f> 0b 0f 0b 44 8d 34 ce e9 ff fd ff ff e8 5b 7e db c8 66 66 2e 0f
[270.043353] RSP: 0018:ffffd26e3eb1bd30 EFLAGS: 00010206
[270.049473] RAX: 0000000000000002 RBX: ffff894d5f5d2680 RCX: 0000000000000000
[270.057510] RDX: 0000000000000200 RSI: 0000000000000246 RDI: ffff894d5f5d2680
[270.065542] RBP: ffff894e42a39b60 R08: 000000000000002a R09: 0000000000000001
[270.073572] R10: ffff894d5f4318c0 R11: 0000000000000000 R12: fffffffffffdffd5
[270.081597] R13: 0000000000000002 R14: ffff894d5f5d2680 R15: ffff894d5f5d2680
[270.089617] FS:  0000000000000000(0000) GS:ffff897a2fe00000(0000) knlGS:0000000000000000
[270.098600] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[270.105201] CR2: 00007f6eac337920 CR3: 00000019e9a22004 CR4: 00000000007726f0
[270.113186] PKRU: 55555554
[270.116747] Call Trace:
[270.120052]  <TASK>
[270.122985]  ? scst_unblock_aborted_cmds+0x30/0x40 [scst]
[270.129335]  ? scst_dev_check_set_UA+0x1e6/0x1f0 [scst]
[270.135502]  scst_finish_internal_cmd+0xad/0x100 [scst]
[270.141662]  scst_process_active_cmd+0x746/0x2820 [scst]
[270.147896]  scst_cmd_thread+0x225/0x550 [scst]
[270.153340]  ? __pfx_autoremove_wake_function+0x10/0x10
[270.159415]  ? __pfx_scst_cmd_thread+0x10/0x10 [scst]
[270.165378]  kthread+0xd2/0x100
[270.169340]  ? __pfx_kthread+0x10/0x10
[270.173914]  ret_from_fork+0x31/0x50
[270.178305]  ? __pfx_kthread+0x10/0x10
[270.182862]  ret_from_fork_asm+0x1a/0x30
[270.187589]  </TASK>
```
Before this stack trace, here are the logs leading up to it.
```
[190.526523] [6648]: scst: Created DLM lockspace scst-xxxxxxxxxxxxxxx for 17:0:0:4
[191.329622] sqatgt(10/0): Enabling target pwwn=21:00:aa:aa:aa:aa:aa:01
[191.329682] qla2xxx [0000:65:00.0]-00af:10: Performing ISP error recovery - ha=00000000815220a5.
[191.382031] qla2xxx [0000:65:00.0]-0075:10: ZIO mode 6 enabled; timer delay (200 us).
[193.582056] qla2xxx [0000:65:00.0]-d302:10: qla2x00_get_fw_version: FC-NVMe is Enabled (0x3c58)
[193.591820] qla2xxx [0000:65:00.0]-11a3:10: SCM in FW: Not Supported
[195.238086] qla2xxx [0000:65:00.0]-500a:10: LOOP UP detected (16 Gbps).
[195.245749] qla2xxx [0000:65:00.0]-500a:21: LOOP UP detected (16 Gbps).
[195.298055] qla2xxx [0000:65:00.0]-700c:10: qla2x00_alloc_iocbs failed.
[198.504586] sqatgt(14/0): Enabling target pwwn=21:00:aa:aa:aa:aa:aa:02
[198.504649] qla2xxx [0000:65:00.1]-00af:14: Performing ISP error recovery - ha=0000000024aefcce.
[198.562088] qla2xxx [0000:65:00.1]-0075:14: ZIO mode 6 enabled; timer delay (200 us).
[200.758117] qla2xxx [0000:65:00.1]-d302:14: qla2x00_get_fw_version: FC-NVMe is Enabled (0x3c58)
[200.767822] qla2xxx [0000:65:00.1]-11a3:14: SCM in FW: Not Supported
[202.406150] qla2xxx [0000:65:00.1]-500a:14: LOOP UP detected (16 Gbps).
[202.413776] qla2xxx [0000:65:00.1]-500a:22: LOOP UP detected (16 Gbps).
[202.482113] qla2xxx [0000:65:00.1]-700c:14: qla2x00_alloc_iocbs failed.
[202.604449] sqatgt(21/1): Enabling target pwwn=22:00:aa:aa:aa:aa:aa:01
[202.612673] sqatgt(22/1): Enabling target pwwn=22:00:aa:aa:aa:aa:aa:02
[203.383030] sqatgt(22/1): Registering initiator: pwwn=20:00:bb:bb:bb:bb:00:00
[203.383055] [1859]: scst: Using security group "22:00:aa:aa:aa:aa:aa:02" for initiator "20:00:bb:bb:bb:bb:00:00" (target 22:00:aa:aa:aa:aa:aa:02)
[203.383533] qla2xxx [0000:65:00.1]-d034:22: qla24xx_do_nack_work create sess success 000000003ecbf497
[203.383545] sqatgt(22/1): Registering initiator: pwwn=20:00:bb:bb:bb:bb:00:01
[203.393744] [1859]: scst: Using security group "22:00:aa:aa:aa:aa:aa:02" for initiator "20:00:bb:bb:bb:bb:00:01" (target 22:00:aa:aa:aa:aa:aa:02)
[203.402490] qla2xxx [0000:65:00.1]-d034:22: qla24xx_do_nack_work create sess success 000000008f0aa949
[203.514520] sqatgt(21/1): Registering initiator: pwwn=20:00:bb:bb:bb:aa:00:00
[203.524723] [177]: scst: Using security group "22:00:aa:aa:aa:aa:aa:01" for initiator "20:00:bb:bb:bb:aa:00:00" (target 22:00:aa:aa:aa:aa:aa:01)
[203.533669] qla2xxx [0000:65:00.0]-d034:21: qla24xx_do_nack_work create sess success 000000002554fc90
[203.533678] sqatgt(21/1): Registering initiator: pwwn=20:00:bb:bb:bb:aa:00:01
[203.551644] [177]: scst: Using security group "22:00:aa:aa:aa:aa:aa:01" for initiator "20:00:bb:bb:bb:aa:00:01" (target 22:00:aa:aa:aa:aa:aa:01)
[203.552102] qla2xxx [0000:65:00.0]-d034:21: qla24xx_do_nack_work create sess success 0000000014d5dc2a
[203.790595] sd 18:0:0:1: Power-on or device reset occurred
[258.382945] sqatgt(21/1): Received task management cmd: lun=0, type=65533, tag=0
[258.382945]
[258.382956] sqatgt(21/1): NEXUS_LOSS_SESS received.
[258.382964] [107]: scst: TM fn NEXUS_LOSS_SESS/6 (mcmd 00000000181a62d7, initiator 20:00:bb:bb:bb:aa:00:01, target 22:00:aa:aa:aa:aa:aa:01)
[258.383026] [4222]: scst: TM fn 6 (mcmd 00000000181a62d7) finished, status 0
[258.432216] sqatgt(21/1): Registering initiator: pwwn=20:00:bb:bb:bb:aa:00:01
[258.432235] [177]: scst: Using security group "22:00:aa:aa:aa:aa:aa:01" for initiator "20:00:bb:bb:bb:aa:00:01" (target 22:00:aa:aa:aa:aa:aa:01)
[258.432685] qla2xxx [0000:65:00.0]-d034:21: qla24xx_do_nack_work create sess success 0000000014d5dc2a
[259.397331] sd 18:0:0:1: Power-on or device reset occurred
[259.433046] sd 18:0:0:3: Power-on or device reset occurred
[269.961764] sd 18:0:0:3: Power-on or device reset occurred
```
1. ALUA failover churn (the qla2xxx ISP error recovery, target re-enables, NEXUS_LOSS) causes the backing devices to stack up reset Unit Attentions. You can see them arriving: `sd 18:0:0:3: Power-on or device reset occurred` at 259.4s and again at 269.961s.  The BUG fires at 269.968s, 7 ms later, on thread `18:0:0:31_0`, which is the SCST device thread for pass-through device `18:0:0:31` (dev_disk in HA forwarding mode, H:C:T:L-named devices, same scheme as the Created DLM lockspace ... for 17:0:0:4 line).
2. The initiator (Cisco UCS WWPNs which are almost certainly ESXi issuing VMFS ATS heartbeats) sends COMPARE AND WRITE so SCST emulates it with an internal READ(16) first, compare, then WRITE(16).
3. At parse time, a READ command gets `resp_data_len = bufflen` (scst_targ.c:1355-1359).512 bytes for a 1-block CAW, which matches `RDX=0x200` in the oops (and `RAX=2 = CHECK_CONDITION`).
4. The internal READ is executed via pass-through and comes back CHECK CONDITION with the unit-attention sense. The pass-through completion path, `scst_do_cmd_done()` at scst_targ.c:2175, copies the SCSI status directly into `cmd->status` and never touches `resp_data_len`. Compare with the path virtual devices use `scst_set_cmd_error_status()` at scst_lib.c:1778 explicitly zeroes `resp_data_len` which is why vdisk-backed LUNs can never trip this and the bug survived so long. The stale `scst_dev_check_set_UA` frame in the backtrace corroborates this. That's `scst_pass_through_cmd_done()` (scst_targ.c:3157) propagating the UA sense it just received, moments before the fatal call.
5. `scst_finish_internal_cmd()` invokes `scst_cwr_read_cmd_finished()`, sees `status != 0` with `resp_data_len == 512`, and the `sBUG` panics the box.

Original PR: https://github.com/truenas/scst/pull/101
