### PR TITLE
NAS-142014 / 25.10.6 / qla2x00t-32gbit: NULL-check ha->tgt.tgt_ops in IRQ-reachable paths (by yocalebo)

### DIFF
--- a/qla2x00t-32gbit/qla_target.c
+++ b/qla2x00t-32gbit/qla_target.c
@@ -1226,6 +1226,13 @@ static int qlt_reset(struct scsi_qla_host *vha, void *iocb, int mcmd)
 	struct imm_ntfy_from_isp *n = (struct imm_ntfy_from_isp *)iocb;
 	unsigned long flags;
 
+	if (unlikely(ha->tgt.tgt_ops == NULL)) {
+		ql_dbg(ql_dbg_tgt, vha, 0xffff,
+		    "qla_target(%d): reset for mcmd %x, but no tgt_ops\n",
+		    vha->vp_idx, mcmd);
+		return -ESRCH;
+	}
+
 	loop_id = le16_to_cpu(n->u.isp24.nport_handle);
 	if (loop_id == 0xFFFF) {
 		/* Global event */
@@ -2172,6 +2179,15 @@ static void qlt_24xx_handle_abts(struct scsi_qla_host *vha,
 	be_id_t s_id;
 	int rc;
 	unsigned long flags;
+
+	if (unlikely(ha->tgt.tgt_ops == NULL)) {
+		ql_dbg(ql_dbg_tgt_mgt, vha, 0xffff,
+		    "qla_target(%d): ABTS: no tgt_ops, rejecting\n",
+		    vha->vp_idx);
+		qlt_24xx_send_abts_resp(ha->base_qpair, abts, FCP_TMF_REJECTED,
+		    false);
+		return;
+	}
 
 	if (le32_to_cpu(abts->fcp_hdr_le.parameter) & ABTS_PARAM_ABORT_SEQ) {
 		ql_dbg(ql_dbg_tgt_mgt, vha, 0xf053,
@@ -5813,6 +5829,11 @@ static void qlt_24xx_atio_pkt(struct scsi_qla_host *vha,
 		    "ATIO pkt, but no tgt (ha %p)", ha);
 		return;
 	}
+	if (unlikely(ha->tgt.tgt_ops == NULL)) {
+		ql_dbg(ql_dbg_tgt, vha, 0xffff,
+		    "ATIO pkt, but no tgt_ops (ha %p)", ha);
+		return;
+	}
 	/*
 	 * In tgt_stop mode we also should allow all requests to pass.
 	 * Otherwise, some commands can stuck.
@@ -6017,6 +6038,12 @@ static void qlt_response_pkt(struct scsi_qla_host *vha,
 	if (unlikely(tgt == NULL)) {
 		ql_dbg(ql_dbg_tgt, vha, 0xe05d,
 		    "qla_target(%d): Response pkt %x received, but no tgt (ha %p)\n",
+		    vha->vp_idx, pkt->entry_type, vha->hw);
+		return;
+	}
+	if (unlikely(vha->hw->tgt.tgt_ops == NULL)) {
+		ql_dbg(ql_dbg_tgt, vha, 0xffff,
+		    "qla_target(%d): Response pkt %x received, but no tgt_ops (ha %p)\n",
 		    vha->vp_idx, pkt->entry_type, vha->hw);
 		return;
 	}


### PR DESCRIPTION
ha->tgt.tgt_ops is per-HBA (qla_hw_data) and is cleared by qlt_lport_deregister() during target driver detach, but the IRQ entry guards in qlt_24xx_atio_pkt() and qlt_response_pkt() only check the per-vport vha->vha_tgt.qla_tgt. If the firmware still delivers target traffic after the lport was deregistered -- e.g. when qlt_disable_vha()'s qla2x00_wait_for_hba_online() fails under a stalled DPC and teardown proceeds anyway, or when a stale enable re-arms target mode -- the first incoming ELS or ABTS dereferences NULL tgt_ops in hard-IRQ context:

  BUG: kernel NULL pointer dereference, address: 0000000000000058
  RIP: qlt_reset+0x53/0x170 [qla2xxx_scst]
   <IRQ>
   qlt_handle_imm_notify+0xe54/0xec0 [qla2xxx_scst]
   qlt_24xx_atio_pkt+0x1aa/0x520 [qla2xxx_scst]
   qlt_24xx_process_atio_queue+0xeb/0x600 [qla2xxx_scst]
   qla83xx_msix_atio_q+0x37/0x50 [qla2xxx_scst]
   </IRQ>

Mainline hit the same crash signatures (see kernel commit [2ef7665dfd88](https://github.com/torvalds/linux/commit/2ef7665dfd88830f15415ba007c7c9a46be7acd8) ("scsi: target: qla2xxx: Wait for stop_phase1 at WWN removal")) and serialized the stop phases, which this driver already inherited; the window above remains reachable regardless, so guard the IR

- qlt_24xx_atio_pkt(), qlt_response_pkt(): drop the packet existing tgt == NULL guards.
- qlt_24xx_handle_abts(): reply FCP_TMF_REJECTED like its paths. This function is also dispatched directly from qlt_24xx_atio_pkt_all_vps() for ABTS on the ATIO queue, qlt_24xx_atio_pkt().
- qlt_reset(): return -ESRCH; all callers in qlt_handle_im send a NACK on failure.

All other tgt.tgt_ops dereferences are reachable only through these funnels or are already guarded (qlt_fc_port_added()).

Original PR: https://github.com/truenas/scst/pull/105
