### PR TITLE
NAS-142018 / 26.0.0-RC.1 / qla2x00t-32gbit: Fail target enable if qlt_lport_register() fails (by yocalebo)

### DIFF
--- a/qla2x00t-32gbit/qla2x00-target/scst_qla2xxx.c
+++ b/qla2x00t-32gbit/qla2x00-target/scst_qla2xxx.c
@@ -2170,8 +2170,13 @@ static int sqa_enable_tgt(struct scst_tgt *scst_tgt, bool enable)
 		   vha->port_name[6], vha->port_name[7]);
 
 	if (enable) {
-		qlt_lport_register(sqa_tgt, wwn_to_u64(vha->port_name),
+		rc = qlt_lport_register(sqa_tgt, wwn_to_u64(vha->port_name),
 		    0, 0, sqa_lport_callback);
+		if (rc != 0) {
+			PRINT_ERROR("sqatgt(%ld/%d): Unable to register lport for target pwwn=%8phC rc=%d",
+				    vha->host_no, vha->vp_idx, vha->port_name, rc);
+			return rc;
+		}
 		qlt_enable_vha(vha);
 	} else {
 		rc = qlt_stop_phase1(tgt);


### PR DESCRIPTION
sqa_enable_tgt() ignored qlt_lport_register()'s return value and called qlt_enable_vha() unconditionally. qlt_lport_register() legitimately fails with -ENODEV e.g. when the matching port is being stopped concurrently ("MODE_TARGET in shutdown") or its scsi_host reference cannot be taken during teardown. Proceeding anyway arms target mode and ATIO interrupt delivery on a port whose ha->tgt.tgt_ops is NULL or about to be NULLed by qlt_lport_deregister(): qlt_enable_vha() clears tgt_stopped and re-initializes the firmware with target mode set, without any check of its own. The first incoming ELS or ABTS then dereferences the NULL tgt_ops in hard-IRQ context (see "qla2x00t-32gbit: NULL-check ha->tgt.tgt_ops in IRQ-reachable paths", which hardens the consumer side of this bug).

Check the return value, log the failure, skip qlt_enable_vha(), and propagate the error so the SCST core reports the enable as failed. No additional tgt_ops check is needed on success since the lport callback has just installed it.

This mirrors mainline linux's tcm_qla2xxx, where a qlt_lport_register() failure propagates out of tcm_qla2xxx_make_lport() and target mode cannot be enabled without a registered lport.

Original PR: https://github.com/truenas/scst/pull/109
