### PR TITLE
NAS-142161 / 26.0.0-RC.1 / isert-scst fix NULL deref in isert_pdu_err on connection teardown (by yocalebo)

### DIFF
--- a/iscsi-scst/kernel/isert-scst/iser_datamover.c
+++ b/iscsi-scst/kernel/isert-scst/iser_datamover.c
@@ -163,6 +163,12 @@ void isert_release_tx_pdu(struct iscsi_cmnd *iscsi_pdu)
 						struct isert_conn, iscsi);
 
 	isert_tx_pdu_init_iscsi(isert_pdu);
+	/*
+	 * Keep pool PDUs pointing at their connection, like
+	 * isert_reinit_rx_pdu() does, so a late error completion
+	 * finds valid state instead of a NULL conn.
+	 */
+	iscsi_pdu->conn = &isert_conn->iscsi;
 
 	spin_lock(&isert_conn->tx_lock);
 	list_move(&isert_pdu->pool_node, &isert_conn->tx_free_list);

--- a/iscsi-scst/kernel/isert-scst/iser_rdma.c
+++ b/iscsi-scst/kernel/isert-scst/iser_rdma.c
@@ -672,6 +672,18 @@ static void isert_handle_wc_error(struct ib_wc *wc)
 			if (test_bit(ISERT_DRAINED_RQ, &isert_conn->flags))
 				isert_sched_conn_drained(isert_conn);
 		} else if (!isert_pdu->is_fake_rx) {
+			/*
+			 * A parentless PDU here, other than the login
+			 * response, means a posted response lost its
+			 * references before this completion was reaped.
+			 * isert_pdu_err() will no-op on it, leaving the
+			 * posting's conn_get() unbalanced and close_conn()
+			 * hung on conn_ref_cnt. Trace loudly.
+			 */
+			if (unlikely(!isert_pdu->iscsi.parent_req &&
+				     isert_pdu != isert_conn->login_rsp_pdu))
+				PRINT_CRIT_ERROR("conn:%p pdu:%p parentless SEND error completion, possible stale pdu",
+						 isert_conn, isert_pdu);
 			isert_pdu_err(&isert_pdu->iscsi);
 		}
 		break;

--- a/iscsi-scst/kernel/isert-scst/isert.c
+++ b/iscsi-scst/kernel/isert-scst/isert.c
@@ -155,7 +155,16 @@ static int isert_process_all_writes(struct iscsi_conn *conn)
 	while ((cmnd = iscsi_get_send_cmnd(conn)) != NULL) {
 		isert_update_len_sn(cmnd);
 		conn_get(conn);
-		isert_pdu_tx(cmnd);
+		if (unlikely(isert_pdu_tx(cmnd))) {
+			/*
+			 * Nothing was posted, so no completion will release
+			 * cmnd. Mirrors the release in isert_pdu_sent().
+			 */
+			if (likely(cmnd->parent_req)) {
+				rsp_cmnd_release(cmnd);
+				conn_put(conn);
+			}
+		}
 	}
 
 	TRACE_EXIT_RES(res);
@@ -254,6 +263,8 @@ static void isert_send_data_rsp(struct iscsi_cmnd *req, u8 *sense,
 				int sense_len, u8 status, int is_send_status)
 {
 	struct iscsi_cmnd *rsp;
+	struct iscsi_conn *conn;
+	int err;
 
 	TRACE_ENTRY();
 
@@ -263,11 +274,29 @@ static void isert_send_data_rsp(struct iscsi_cmnd *req, u8 *sense,
 
 	isert_update_len_sn(rsp);
 
-	conn_get(rsp->conn);
+	conn = rsp->conn;
+
+	/*
+	 * Once posted, rsp's reference is owned by the send completion
+	 * (isert_pdu_sent()/isert_pdu_err()). This path bypasses
+	 * iscsi_get_send_cmnd(), so mark the rsp as being processed here,
+	 * or req_cmnd_release_force() will consider it not sent yet and
+	 * put the same reference while the WRs are still posted.
+	 */
+	spin_lock_bh(&conn->write_list_lock);
+	rsp->write_processing_started = 1;
+	spin_unlock_bh(&conn->write_list_lock);
+
+	conn_get(conn);
 	if (status != SAM_STAT_CHECK_CONDITION)
-		isert_send_data_in(req, rsp);
+		err = isert_send_data_in(req, rsp);
 	else
-		isert_pdu_tx(rsp);
+		err = isert_pdu_tx(rsp);
+	if (unlikely(err)) {
+		/* Nothing was posted, so no completion will release rsp */
+		rsp_cmnd_release(rsp);
+		conn_put(conn);
+	}
 
 	TRACE_EXIT();
 }
@@ -367,6 +396,9 @@ int isert_data_in_sent(struct iscsi_cmnd *din)
 void isert_pdu_err(struct iscsi_cmnd *pdu)
 {
 	struct iscsi_conn *conn = pdu->conn;
+
+	if (unlikely(!conn)) /* pdu was already released and recycled */
+		return;
 
 	if (!conn->session) /* we are still in login phase */
 		return;

--- a/iscsi-scst/kernel/isert-scst/isert.c
+++ b/iscsi-scst/kernel/isert-scst/isert.c
@@ -397,8 +397,18 @@ void isert_pdu_err(struct iscsi_cmnd *pdu)
 {
 	struct iscsi_conn *conn = pdu->conn;
 
-	if (unlikely(!conn)) /* pdu was already released and recycled */
+	if (unlikely(!conn)) {
+		/*
+		 * A PDU was recycled while its WR completion was still
+		 * pending, which the write_processing_started ownership
+		 * fix is supposed to make impossible. The posting's
+		 * conn_get() cannot be balanced from here (the owner is
+		 * unknown), so close_conn() will hang on conn_ref_cnt.
+		 * Trace loudly so the early-release path can be found.
+		 */
+		PRINT_CRIT_ERROR("stale recycled pdu %p in isert_pdu_err", pdu);
 		return;
+	}
 
 	if (!conn->session) /* we are still in login phase */
 		return;


### PR DESCRIPTION
A buggy initiator rapidly connecting and disconnecting over iSER can panic the target. isert_send_data_rsp posts SCSI data and status responses directly, bypassing iscsi_get_send_cmnd, so a posted response never gets write_processing_started set. When the connection is torn down mid I/O, req_cmnd_release_force therefore treats the posted response as never sent and drops its only reference, the same reference the send completion handler drops again once the flushed WR error CQE is reaped. The first put recycles the PDU back into the tx pool, which memsets the embedded iscsi_cmnd, and the stale completion then dereferences the zeroed conn pointer in isert_pdu_err.

```
BUG kernel NULL pointer dereference, address 0000000000000008 Workqueue isert_cq_000000008e39f804 isert_cq_comp_work_cb [isert_scst] RIP isert_pdu_err+0xd/0x40 [isert_scst]
Call Trace
 isert_poll_cq+0x1f6/0x390 [isert_scst]
 isert_cq_comp_work_cb+0x1d/0x50 [isert_scst]
 process_one_work+0x194/0x350
 worker_thread+0x1a1/0x310
 kthread+0xfc/0x240
 ret_from_fork+0x22e/0x260
 ret_from_fork_asm+0x1a/0x30
```

Fix the ownership at the root. Mark responses posted by isert_send_data_rsp with write_processing_started under write_list_lock so teardown leaves wire owned responses to their completion handler, and release the wire references at the failure site when posting fails since no completion will ever arrive. Add the same failure handling to isert_process_all_writes. As defense in depth, keep recycled tx pool PDUs pointing at their connection, matching the rx recycle path, and bail out of isert_pdu_err when conn is NULL.

Original PR: https://github.com/truenas/scst/pull/120
