### PR TITLE
NAS-142258 / 26.0.0-RC.1 / scst keep the old acg installed during session reassignment (by yocalebo)

### DIFF
--- a/scst/src/scst_lib.c
+++ b/scst/src/scst_lib.c
@@ -3044,8 +3044,11 @@ static void scst_check_reassign_sess(struct scst_session *sess)
 		"acg %s", sess, sess->initiator_name, sess->acg->acg_name,
 		acg->acg_name);
 
+	/*
+	 * Keep the old acg in place until the switch below. The TM path
+	 * reads sess->acg without scst_mutex and must never see NULL.
+	 */
 	old_acg = sess->acg;
-	sess->acg = NULL; /* to catch implicit dependencies earlier */
 
 retry_add:
 	add_failed = false;
@@ -5526,8 +5529,8 @@ static __be16 scst_dif_ip_fn(const void *data, unsigned int len);
 
 /*
  * scst_mutex supposed to be held, there must not be parallel activity in this
- * session. May be invoked from inside scst_check_reassign_sessions() which
- * means that sess->acg can be NULL.
+ * session. May be invoked from inside scst_check_reassign_sessions() in which
+ * case sess->acg may still point to the old acg, so use acg_dev->acg.
  */
 static int scst_alloc_add_tgt_dev(struct scst_session *sess,
 	struct scst_acg_dev *acg_dev, struct scst_tgt_dev **out_tgt_dev)

--- a/scst/src/scst_main.c
+++ b/scst/src/scst_main.c
@@ -1773,8 +1773,8 @@ int scst_add_threads(struct scst_cmd_threads *cmd_threads, struct scst_device *d
 		if (tgt_dev) {
 			int rc;
 			/*
-			 * sess->acg can be NULL here, if called from
-			 * scst_check_reassign_sess()!
+			 * sess->acg may still point to the old acg here,
+			 * if called from scst_check_reassign_sess().
 			 */
 			rc = set_cpus_allowed_ptr(thr->cmd_thread,
 						  &tgt_dev->acg_dev->acg->acg_cpu_mask);


### PR DESCRIPTION
scst_check_reassign_sess() cleared sess->acg for the whole time it rebuilt the session's tgt_dev list. That window includes one synchronize_rcu() call per replaced or deleted LUN and the session stays fully visible to its initiator throughout. Activity suspension does not close the window. scst_post_rx_mgmt_cmd() queues a newly received task management command to the active list unconditionally, the TM thread picks it up immediately, and the first statement of scst_mgmt_cmd_init() dereferences mcmd->sess->acg before the scst_get_mcmd() suspension check runs. An ABORT_TASK arriving while its own session was mid reassignment therefore crashed the TM thread with a NULL pointer dereference at offset 0x464, which is acg_black_hole_type. Every task management function is affected because the dereference precedes the switch on the function code.

Fix this by leaving the old acg pointer installed until the existing single assignment of the new acg near the end of the function. The session holds a reference on the old acg until scst_put_acg() runs and scst_mutex is held across the whole window, so the pointer stays valid. An audit found no code that depends on sess->acg being NULL during reassignment. The one helper that runs inside the window, scst_alloc_add_tgt_dev(), has used acg_dev->acg instead since upstream commit e7179af46 fixed the same class of crash in 2014. Lockless readers now see the coherent old group instead of NULL, which is already how acg_black_hole_type changes are observed. This also covers the same latent dereferences in iscsi-scst session creation and in the copy manager. Upstream SCST still has this bug and it is reported there as issue 367.

The sanitized oops and the kernel log leading up to it follow. Initiator and target names were replaced and everything else is verbatim. The final reassignment line and the fatal ABORT_TASK are for the same session.

<6>[298607.455265] [11305]: iscsi-scst: iSCSI TM fn 1 <6>[298607.455291] [11305]: scst: TM fn ABORT_TASK/0 (mcmd 00000000998fe93d, initiator iqn.1998-01.com.vmware:esx1:648341046:64#192.168.190.211, target iqn.2005-12.org.freenas.ctl:truenas:target1) <1>[298607.455315] BUG: kernel NULL pointer dereference, address: 0000000000000464 <1>[298607.455763] #PF: supervisor read access in kernel mode <1>[298607.456118] #PF: error_code(0x0000) - not-present page <6>[298607.456470] PGD 61812f9067 P4D 61812f9067 PUD 611e1f1067 PMD 0 <4>[298607.456836] Oops: Oops: 0000 [# 1] PREEMPT SMP NOPTI
<4>[298607.457202] CPU: 32 UID: 0 PID: 11238 Comm: scsi_tm Tainted: P           OE      6.12.91-production+truenas # 1
<4>[298607.457615] Tainted: [P]=PROPRIETARY_MODULE, [O]=OOT_MODULE, [E]=UNSIGNED_MODULE
<4>[298607.458011] Hardware name: iXsystems TRUENAS-F60-HA/TRUENAS-F60-HA, BIOS MWH3LJ-15.09.00b 05/16/2023
<4>[298607.458417] RIP: 0010:scst_tm_thread+0x11f/0x17a0 [scst]
<4>[298607.458880] Code: 89 46 08 e8 33 7e 05 e3 41 8b 46 1c 83 f8 03 74 60 0f 8f 69 01 00 00 85 c0 0f 85 1a 01 00 00 49 8b 5e 10 48 8b 83 e8 02 00 00 <8b> 80 64 04 00 00 83 e8 02 83 e0 fd 0f 84 9d 0d 00 00 41 8b 46 20
<4>[298607.459828] RSP: 0018:ffffcec7cf7f3e28 EFLAGS: 00010246
<4>[298607.460287] RAX: 0000000000000000 RBX: ffff8dc43b0ec600 RCX: ffffffffc22877f8
<4>[298607.460753] RDX: ffffffffc2287820 RSI: 0000000000000083 RDI: ffffffffc2287830
<4>[298607.461222] RBP: ffffcec7cf7f3e50 R08: ffffffffc22877f8 R09: 0000000000000001
<4>[298607.461700] R10: 0000000000000001 R11: 0000000000000000 R12: ffffcec8466ef7d8
<4>[298607.462215] R13: ffff8df783d7da00 R14: ffff8e169ba98bd0 R15: ffffffffc207bde0
<4>[298607.462715] FS:  0000000000000000(0000) GS:ffff8dd5ef800000(0000) knlGS:0000000000000000
<4>[298607.463241] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
<4>[298607.463778] CR2: 0000000000000464 CR3: 0000006181cdc004 CR4: 0000000000f70ef0
<4>[298607.464300] PKRU: 55555554
<4>[298607.464818] Call Trace:
<4>[298607.465342]  <TASK>
<4>[298607.465861]  ? srso_alias_return_thunk+0x5/0xfbef5
<4>[298607.466387]  ? finish_task_switch.isra.0+0x88/0x2d0
<4>[298607.466934]  ? __pfx_autoremove_wake_function+0x10/0x10
<4>[298607.467491]  ? __pfx_scst_tm_thread+0x10/0x10 [scst]
<4>[298607.468072]  kthread+0xd2/0x100
<4>[298607.468614]  ? __pfx_kthread+0x10/0x10
<4>[298607.469157]  ret_from_fork+0x34/0x50
<4>[298607.469731]  ? __pfx_kthread+0x10/0x10
<4>[298607.470276]  ret_from_fork_asm+0x1a/0x30
<4>[298607.470939]  </TASK>

Aug 10 20:27:25 truenas kernel: [11170]: scst: sess 00000000c4f34df8 (initiator iqn.1998-01.com.vmware:esx3:271329254:64#192.168.190.211) will be reassigned from acg security_group to acg iqn.2005-12.org.freenas.ctl:truenas:target1
Aug 10 20:27:26 truenas kernel: [11170]: scst: sess 000000009b2602df (initiator iqn.1998-01.com.vmware:esx1:648341046:64#192.168.191.211) will be reassigned from acg security_group to acg iqn.2005-12.org.freenas.ctl:truenas:target1
Aug 10 20:27:27 truenas kernel: [11170]: scst: sess 00000000b8e2d883 (initiator iqn.1998-01.com.vmware:esx3:271329254:64#192.168.191.211) will be reassigned from acg security_group to acg iqn.2005-12.org.freenas.ctl:truenas:target1
Aug 10 20:27:28 truenas kernel: [11170]: scst: sess 00000000d045b924 (initiator iqn.1998-01.com.vmware:esx6:1668310150:64#192.168.191.211) will be reassigned from acg security_group to acg iqn.2005-12.org.freenas.ctl:truenas:target1
Aug 10 20:27:29 truenas kernel: [11170]: scst: Waiting for 2 active commands to complete...
Aug 10 20:27:29 truenas kernel: [11170]: scst: All active commands completed
Aug 10 20:27:29 truenas kernel: [11170]: scst: sess 00000000f7aa935f (initiator iqn.1998-01.com.vmware:esx5:737429025:64#192.168.190.211) will be reassigned from acg security_group to acg iqn.2005-12.org.freenas.ctl:truenas:target1
Aug 10 20:27:30 truenas kernel: [11170]: scst: sess 000000003431d3a2 (initiator iqn.1998-01.com.vmware:esx6:1668310150:64#192.168.190.211) will be reassigned from acg security_group to acg iqn.2005-12.org.freenas.ctl:truenas:target1
Aug 10 20:27:30 truenas kernel: [11170]: scst: sess 00000000ce4462ff (initiator iqn.1998-01.com.vmware:esx4:1487820870:64#192.168.190.211) will be reassigned from acg security_group to acg iqn.2005-12.org.freenas.ctl:truenas:target1
Aug 10 20:27:31 truenas kernel: [11170]: scst: sess 000000001d8fac5a (initiator iqn.1998-01.com.vmware:esx1:648341046:64#192.168.190.211) will be reassigned from acg security_group to acg iqn.2005-12.org.freenas.ctl:truenas:target1
Aug 10 20:27:32 truenas kernel: [11170]: scst: sess 00000000f249eeba (initiator iqn.1998-01.com.vmware:esx5:737429025:64#192.168.191.211) will be reassigned from acg security_group to acg iqn.2005-12.org.freenas.ctl:truenas:target1
Aug 10 20:27:33 truenas kernel: [11170]: scst: sess 0000000043bdef49 (initiator iqn.1998-01.com.vmware:esx2:1461901680:64#192.168.190.211) will be reassigned from acg security_group to acg iqn.2005-12.org.freenas.ctl:truenas:target1
Aug 10 20:27:34 truenas kernel: [11170]: scst: sess 0000000046d79e81 (initiator iqn.1998-01.com.vmware:esx2:1461901680:64#192.168.191.211) will be reassigned from acg security_group to acg iqn.2005-12.org.freenas.ctl:truenas:target1
Aug 10 20:27:35 truenas kernel: [11170]: scst: sess 000000006a6387f1 (initiator iqn.1998-01.com.vmware:esx7:1210241541:64#192.168.191.211) will be reassigned from acg security_group to acg iqn.2005-12.org.freenas.ctl:truenas:target1
Aug 10 20:27:36 truenas kernel: [11170]: scst: sess 00000000b50bcca3 (initiator iqn.1998-01.com.vmware:esx7:1210241541:64#192.168.190.211) will be reassigned from acg security_group to acg iqn.2005-12.org.freenas.ctl:truenas:target1
Aug 10 20:27:36 truenas kernel: [11303]: iscsi-scst: iSCSI TM fn 1
Aug 10 20:27:36 truenas kernel: [11303]: scst: TM fn ABORT_TASK/0 (mcmd 00000000d9e646f0, initiator iqn.1998-01.com.vmware:esx2:1461901680:64#192.168.190.211, target iqn.2005-12.org.freenas.ctl:truenas:target1)
Aug 10 20:27:36 truenas kernel: [11238]: scst: TM fn 0 (mcmd 00000000d9e646f0) finished, status -1
Aug 10 20:27:36 truenas kernel: [11238]: iscsi-scst: iSCSI TM fn 1 finished, status 0, dropped 0
Aug 10 20:27:36 truenas kernel: [11304]: iscsi-scst: iSCSI TM fn 1
Aug 10 20:27:36 truenas kernel: [11304]: scst: TM fn ABORT_TASK/0 (mcmd 000000007b851a39, initiator iqn.1998-01.com.vmware:esx3:271329254:64#192.168.190.211, target iqn.2005-12.org.freenas.ctl:truenas:target1)
Aug 10 20:27:36 truenas kernel: [11238]: scst: TM fn 0 (mcmd 000000007b851a39) finished, status -1
Aug 10 20:27:36 truenas kernel: [11238]: iscsi-scst: iSCSI TM fn 1 finished, status 0, dropped 0
Aug 10 20:27:37 truenas kernel: [11170]: scst: sess 000000001d27ec8a (initiator iqn.1998-01.com.vmware:esx4:1487820870:64#192.168.191.211) will be reassigned from acg security_group to acg iqn.2005-12.org.freenas.ctl:truenas:target1
Aug 10 20:27:37 truenas kernel: [11295]: iscsi-scst: iSCSI TM fn 1
Aug 10 20:27:37 truenas kernel: [11295]: scst: TM fn ABORT_TASK/0 (mcmd 00000000f5e1ff30, initiator iqn.1998-01.com.vmware:esx4:1487820870:64#192.168.190.211, target iqn.2005-12.org.freenas.ctl:truenas:target1)
Aug 10 20:27:37 truenas kernel: [11295]: iscsi-scst: iSCSI TM fn 1
Aug 10 20:27:37 truenas kernel: [11295]: scst: TM fn ABORT_TASK/0 (mcmd 00000000450e55bc, initiator iqn.1998-01.com.vmware:esx4:1487820870:64#192.168.190.211, target iqn.2005-12.org.freenas.ctl:truenas:target1)
Aug 10 20:27:37 truenas kernel: [11238]: scst: TM fn 0 (mcmd 00000000f5e1ff30) finished, status -1
Aug 10 20:27:37 truenas kernel: [11238]: iscsi-scst: iSCSI TM fn 1 finished, status 0, dropped 0
Aug 10 20:27:37 truenas kernel: [11238]: scst: TM fn 0 (mcmd 00000000450e55bc) finished, status -1
Aug 10 20:27:37 truenas kernel: [11238]: iscsi-scst: iSCSI TM fn 1 finished, status 0, dropped 0
Aug 10 20:27:37 truenas kernel: [11303]: iscsi-scst: iSCSI TM fn 1
Aug 10 20:27:37 truenas kernel: [11303]: scst: TM fn ABORT_TASK/0 (mcmd 00000000eb53e996, initiator iqn.1998-01.com.vmware:esx2:1461901680:64#192.168.190.211, target iqn.2005-12.org.freenas.ctl:truenas:target1)
Aug 10 20:27:37 truenas kernel: [11238]: scst: TM fn 0 (mcmd 00000000eb53e996) finished, status -1
Aug 10 20:27:37 truenas kernel: [11238]: iscsi-scst: iSCSI TM fn 1 finished, status 0, dropped 0
Aug 10 20:27:38 truenas kernel: [11170]: scst: Added name *# 192.168.190.211 to group security_group (target iqn.2005-12.org.freenas.ctl:truenas:target1)
Aug 10 20:27:38 truenas kernel: [11170]: scst: sess 00000000c4f34df8 (initiator iqn.1998-01.com.vmware:esx3:271329254:64#192.168.190.211) will be reassigned from acg iqn.2005-12.org.freenas.ctl:truenas:target1 to acg security_group
Aug 10 20:27:38 truenas kernel: [11170]: scst: sess 000000003431d3a2 (initiator iqn.1998-01.com.vmware:esx6:1668310150:64#192.168.190.211) will be reassigned from acg iqn.2005-12.org.freenas.ctl:truenas:target1 to acg security_group
Aug 10 20:27:38 truenas kernel: [11170]: scst: sess 00000000f7aa935f (initiator iqn.1998-01.com.vmware:esx5:737429025:64#192.168.190.211) will be reassigned from acg iqn.2005-12.org.freenas.ctl:truenas:target1 to acg security_group
Aug 10 20:27:38 truenas kernel: [11170]: scst: sess 00000000ce4462ff (initiator iqn.1998-01.com.vmware:esx4:1487820870:64#192.168.190.211) will be reassigned from acg iqn.2005-12.org.freenas.ctl:truenas:target1 to acg security_group
Aug 10 20:27:38 truenas kernel: [11170]: scst: sess 00000000b50bcca3 (initiator iqn.1998-01.com.vmware:esx7:1210241541:64#192.168.190.211) will be reassigned from acg iqn.2005-12.org.freenas.ctl:truenas:target1 to acg security_group
Aug 10 20:27:38 truenas kernel: [11170]: scst: sess 0000000043bdef49 (initiator iqn.1998-01.com.vmware:esx2:1461901680:64#192.168.190.211) will be reassigned from acg iqn.2005-12.org.freenas.ctl:truenas:target1 to acg security_group
Aug 10 20:27:38 truenas kernel: [11170]: scst: sess 000000001d8fac5a (initiator iqn.1998-01.com.vmware:esx1:648341046:64#192.168.190.211) will be reassigned from acg iqn.2005-12.org.freenas.ctl:truenas:target1 to acg security_group
Aug 10 20:27:38 truenas kernel: [11305]: iscsi-scst: iSCSI TM fn 1
Aug 10 20:27:38 truenas kernel: [11305]: scst: TM fn ABORT_TASK/0 (mcmd 00000000998fe93d, initiator iqn.1998-01.com.vmware:esx1:648341046:64#192.168.190.211, target iqn.2005-12.org.freenas.ctl:truenas:target1)

Original PR: https://github.com/truenas/scst/pull/123
