### PR TITLE
NAS-142264 / 25.10.7 / scst do not hold a list cursor across the scst_acg_del_lun mutex drop (by yocalebo)

### DIFF
--- a/scst/src/scst_main.c
+++ b/scst/src/scst_main.c
@@ -1177,10 +1177,27 @@ static struct scst_device *__scst_lookup_device(struct scsi_device *scsidp)
 	return NULL;
 }
 
+static void scst_dev_del_all_luns(struct scst_device *dev)
+{
+	struct scst_acg_dev *acg_dev;
+
+	lockdep_assert_held(&scst_mutex);
+
+	/*
+	 * scst_acg_del_lun() drops scst_mutex, so concurrent ACG teardown
+	 * can unlink entries. Restart from the list head every iteration.
+	 */
+	while (!list_empty(&dev->dev_acg_dev_list)) {
+		acg_dev = list_first_entry(&dev->dev_acg_dev_list,
+					   struct scst_acg_dev,
+					   dev_acg_dev_list_entry);
+		scst_acg_del_lun(acg_dev->acg, acg_dev->lun, true);
+	}
+}
+
 static void scst_unregister_device(struct scsi_device *scsidp)
 {
 	struct scst_device *dev;
-	struct scst_acg_dev *acg_dev, *aa;
 	DECLARE_COMPLETION_ONSTACK(c);
 
 	TRACE_ENTRY();
@@ -1204,10 +1221,7 @@ static void scst_unregister_device(struct scsi_device *scsidp)
 
 	scst_dg_dev_remove_by_dev(dev);
 
-	list_for_each_entry_safe(acg_dev, aa, &dev->dev_acg_dev_list,
-				 dev_acg_dev_list_entry) {
-		scst_acg_del_lun(acg_dev->acg, acg_dev->lun, true);
-	}
+	scst_dev_del_all_luns(dev);
 
 	dev->remove_completion = &c;
 
@@ -1460,7 +1474,6 @@ void scst_unregister_virtual_device(int id,
 				    void *arg)
 {
 	struct scst_device *d, *dev = NULL;
-	struct scst_acg_dev *acg_dev, *aa;
 	DECLARE_COMPLETION_ONSTACK(c);
 
 	TRACE_ENTRY();
@@ -1489,10 +1502,7 @@ void scst_unregister_virtual_device(int id,
 
 	scst_dg_dev_remove_by_dev(dev);
 
-	list_for_each_entry_safe(acg_dev, aa, &dev->dev_acg_dev_list,
-				 dev_acg_dev_list_entry) {
-		scst_acg_del_lun(acg_dev->acg, acg_dev->lun, true);
-	}
+	scst_dev_del_all_luns(dev);
 
 	dev->remove_completion = &c;
 


### PR DESCRIPTION
scst_unregister_device() and scst_unregister_virtual_device() walked dev->dev_acg_dev_list with list_for_each_entry_safe() while calling scst_acg_del_lun() on each entry. That function is not atomic under scst_mutex. After unlinking the acg_dev it drops the mutex to wait for outstanding commands and for an RCU grace period, then relocks and frees. Any acg_dev teardown that wins the mutex during that window invalidates the walker's saved next pointer. Target unregistration is such a teardown. scst_del_acg() unlinks each acg_dev from the device side only, leaving it on acg->acg_dev_list with its device side list entry poisoned, and defers the free to the acg release work. When the device walker resumed on that stale cursor it looked the entry up again by LUN, found the half deleted node, and performed a second list_del() on the poisoned entry. With list hardening that is a general protection fault on LIST_POISON2. Without it the same race can write through reused slab memory, free the acg_dev twice, and underflow the device refcount.

Fix this by restarting from the list head on every iteration instead of carrying a cursor across the call. Both functions now share a new scst_dev_del_all_luns() helper so the loop and its locking assumption live in one place. The list is read again under
scst_mutex after scst_acg_del_lun() returns, so entries removed by a concurrent teardown are simply no longer seen. Progress is guaranteed because an entry present on dev->dev_acg_dev_list is always still findable in its group while scst_mutex is held, so each call removes the first entry.

This was hit in production on an HA system during failover. The scst service restart was tearing down all iSCSI targets while iscsid was logging out the initiator sessions to the peer node, whose pass through devices carry LUNs in both the dying target's group and the copy manager group. The same window exists upstream and the crash is unfixed there. The sanitized oops and the log leading up to it follow. Device, target, and dataset names were replaced and everything else is verbatim.
```
<6>[  197.409288] [4056]: dev_vdisk: dev vol1: ALUA state change from transitioning to active finished, reopening FD <6>[  197.411585] [4056]: dev_vdisk: Auto enable thin provisioning for device /dev/zvol/tank/iscsi/vol1 <6>[  197.411605] [4056]: dev_vdisk: dev vol2: ALUA state change from transitioning to active started, not closing FD <6>[  197.411613] [4056]: dev_vdisk: dev vol2: ALUA state change from transitioning to active finished, reopening FD <6>[  197.413555] [4056]: dev_vdisk: Auto enable thin provisioning for device /dev/zvol/tank/iscsi/vol2 <6>[  197.413572] [4056]: dev_vdisk: dev vol3: ALUA state change from transitioning to active started, not closing FD <6>[  197.413577] [4056]: dev_vdisk: dev vol3: ALUA state change from transitioning to active finished, reopening FD <6>[  197.415219] [4056]: dev_vdisk: Auto enable thin provisioning for device /dev/zvol/tank/iscsi/vol3 <6>[  197.415254] [4056]: scst: Changed ALUA state of targets/controller_B into active <6>[  197.498596] [4090]: iscsi-scst: Releasing allocated resources <6>[  197.544339] dlm: scst-6c1beaf8ea1e06e: group event done 0 <6>[  197.544431] dlm: scst-6c1beaf8ea1e06e: release_lockspace final free <6>[  197.544441] [5516]: scst: released lockspace for 6c1beaf8ea1e06e <6>[  197.544668] [5517]: scst: 6:0:0:3: changing cluster_mode from 1 into 0 <6>[  197.544860] dlm: scst-fd7f6fbaf47830f: leaving the lockspace group... <6>[  202.561564] dlm: scst-fd7f6fbaf47830f: group event done 0 <6>[  202.561722] dlm: scst-fd7f6fbaf47830f: release_lockspace final free <6>[  202.561744] [5517]: scst: released lockspace for fd7f6fbaf47830f <6>[  202.561900] [5519]: scst: 6:0:0:4: changing cluster_mode from 1 into 0 <6>[  202.562196] dlm: scst-02a66387a322ebf: leaving the lockspace group... <6>[  207.575426] dlm: scst-02a66387a322ebf: group event done 0 <6>[  207.575573] dlm: scst-02a66387a322ebf: release_lockspace final free <6>[  207.575651] [5519]: scst: released lockspace for 02a66387a322ebf <6>[  207.575932] [4394]: scst: Removed LUN 0 from group copy_manager_tgt (target copy_manager_tgt) <6>[  207.617025] [4090]: scst: Target iqn.2005-10.org.freenas.ctl:truenas-ha for template iscsi unregistered successfully <4>[  207.617072] Oops: general protection fault, probably for non-canonical address 0xdead000000000122: 0000 [#1] PREEMPT SMP NOPTI
<4>[  207.617594] CPU: 1 UID: 0 PID: 4394 Comm: iscsid Tainted: P           OE      6.12.91-production+truenas #1
<4>[  207.617974] Tainted: [P]=PROPRIETARY_MODULE, [O]=OOT_MODULE, [E]=UNSIGNED_MODULE
<4>[  207.618356] Hardware name: iXsystems TRUENAS-H10-HA/X12SDV-4C-SP6F, BIOS 1.8.V2 01/15/2025
<4>[  207.618754] RIP: 0010:__scst_acg_del_lun+0x1ed/0x310 [scst]
<4>[  207.619247] Code: 89 7e 08 4d 89 b4 24 18 02 00 00 49 89 b4 24 20 02 00 00 48 89 3e 48 8b 3b e9 b9 fe ff ff 48 8b 43 28 48 8b 53 20 48 8d 7b 20 <48> 3b 38 0f 85 fe 00 00 00 48 3b 7a 08 0f 85 f4 00 00 00 48 89 42
<4>[  207.620172] RSP: 0018:ff4e0ed685757810 EFLAGS: 00010246
<4>[  207.620651] RAX: dead000000000122 RBX: ff24d36991e03d20 RCX: ff24d369c01f6000
<4>[  207.621191] RDX: dead000000000100 RSI: ff24d3699e06acf0 RDI: ff24d36991e03d40
<4>[  207.621761] RBP: ff24d369aaf42800 R08: 0000000000000000 R09: 0000000080190018
<4>[  207.622342] R10: 0000000000000000 R11: 0000000080190018 R12: ff24d3699e06aae8
<4>[  207.622936] R13: ff24d3699e06aae8 R14: ff4e0ed685757868 R15: 0000000000000000
<4>[  207.623543] FS:  00007f1c5a8e4d80(0000) GS:ff24d378bfc80000(0000) knlGS:0000000000000000
<4>[  207.624170] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
<4>[  207.624798] CR2: 00007f7ed18a32f0 CR3: 000000011f51a001 CR4: 0000000000773ef0
<4>[  207.625458] PKRU: 55555554
<4>[  207.626105] Call Trace:
<4>[  207.626752]  <TASK>
<4>[  207.627391]  ? kmem_cache_free+0x2e9/0x3b0
<4>[  207.628051]  scst_acg_del_lun+0x4e/0x1f0 [scst]
<4>[  207.628797]  scst_remove+0x14d/0x310 [scst]
<4>[  207.629451]  device_del+0x10f/0x3e0
<4>[  207.629922]  device_unregister+0x17/0x60
<4>[  207.630395]  __scsi_remove_device+0x11a/0x180 [scsi_mod]
<4>[  207.630906]  scsi_remove_target+0x1a5/0x220 [scsi_mod]
<4>[  207.631415]  __iscsi_unbind_session+0xd4/0x220 [scsi_transport_iscsi]
<4>[  207.631940]  iscsi_remove_session+0x107/0x200 [scsi_transport_iscsi]
<4>[  207.632466]  iscsi_session_remove+0x1d/0x30 [libiscsi]
<4>[  207.632983]  iscsi_sw_tcp_session_destroy+0x4c/0x80 [iscsi_tcp]
<4>[  207.633513]  iscsi_if_rx+0x1bcf/0x21e0 [scsi_transport_iscsi]
<4>[  207.634060]  ? kmalloc_reserve+0x93/0x100
<4>[  207.634592]  netlink_unicast+0x1d8/0x2d0
<4>[  207.635130]  netlink_sendmsg+0x222/0x490
<4>[  207.635669]  ? aa_sk_perm+0x46/0x210
<4>[  207.636208]  ____sys_sendmsg+0x37c/0x3a0
<4>[  207.636748]  ? copy_msghdr_from_user+0x7d/0xc0
<4>[  207.637299]  ___sys_sendmsg+0x9a/0xe0
<4>[  207.637849]  __sys_sendmsg+0x87/0xe0
<4>[  207.638393]  do_syscall_64+0x87/0x1a0
<4>[  207.642790]  entry_SYSCALL_64_after_hwframe+0x76/0x7e
<4>[  207.647918]  </TASK>
<0>[  207.713820] Kernel panic - not syncing: Fatal exception

Original PR: https://github.com/truenas/scst/pull/126
